### PR TITLE
add optional -fPIC flag to Intel CXX flag

### DIFF
--- a/cmake/CXXCompilers.cmake
+++ b/cmake/CXXCompilers.cmake
@@ -63,6 +63,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES Intel)
             "${CMAKE_CXX_FLAGS} -openmp"
             )
     endif()
+    if(ENABLE_STATIC_LINKING)
+        set(CMAKE_CXX_FLAGS
+            "${CMAKE_CXX_FLAGS} -fPIC"
+            )
+    endif()
 endif ()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES PGI)


### PR DESCRIPTION
Currently only on `xcint` branch.