### PR TITLE
do not specify ARCHIVE in libxcfun install target; fixes #5

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,5 +44,4 @@ add_custom_command (
 	COMMAND geninterface
 	)
 
-install(TARGETS xcfun ARCHIVE DESTINATION lib)
-
+install(TARGETS xcfun DESTINATION lib)


### PR DESCRIPTION
This indeed defaults to static and with `cmake -DBUILD_SHARED_LIBS=1 ..` can be changed to dynamic.