### PR TITLE
make it possible to set XC_MAX_ORDER from outside; fixes #6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,12 @@ set (XCFun_VERSION_MINOR 0)
 option(XCFUN_NO_STDC++ "Disable libsrdc++" OFF)
 option(XCFUN_ENABLE_TESTS "Enable tests" ON)
 
+
+# set maximum derivative order
+set(XC_MAX_ORDER "2" CACHE STRING "Maximum derivative order")
+add_definitions(-DXC_MAX_ORDER=${XC_MAX_ORDER})
+
+
 include(ConfigCompilerFlags)
 if (CMAKE_COMPILER_IS_GNUCXX)
 	set (CMAKE_CXX_FLAGS "-Wall -Wno-unknown-pragmas -Wno-sign-compare -fno-rtti -fno-exceptions ")

--- a/src/config.h
+++ b/src/config.h
@@ -3,7 +3,10 @@
 
 //Maximum derivative order. Lower orders can be generated
 //for GGA's and MGGA's, to avoid huge code size.
+#ifndef XC_MAX_ORDER
 #define XC_MAX_ORDER 2
+#endif
+
 #define XC_LDA_MAX_ORDER XC_MAX_ORDER
 #define XC_GGA_MAX_ORDER XC_MAX_ORDER
 #define XC_MGGA_MAX_ORDER XC_MAX_ORDER


### PR DESCRIPTION
Can be done with:
```
$ cmake -DXC_MAX_ORDER=3 ..
```

If nothing is specified, max order defaults to 2 also with Makefiles
which do not set this.