### PR TITLE
Fix relicensing statements to comply with format

### DIFF
--- a/RELICENSE/AndreGomes.md
+++ b/RELICENSE/AndreGomes.md
@@ -4,8 +4,8 @@ This is a statement by Andre Severo Pereira Gomes
 that grants permission to relicense its copyrights in the XCFun C++
 library under the Mozilla Public License v2 (MPLv2).
 
-A portion of the commits made by the GitHub handle aspgomes, with
-commit author Andre Gomes, are copyright of Andre Severo Pereira Gomes.
+A portion of the commits made by the GitHub handle "aspgomes", with
+commit author "Andre Gomes", are copyright of Andre Severo Pereira Gomes.
 This document hereby grants the XCFun project team to relicense XCFun,
 including all past, present and future contributions of the author listed above.
 

--- a/RELICENSE/ChristophJacob.md
+++ b/RELICENSE/ChristophJacob.md
@@ -1,11 +1,11 @@
 # Permission to Relicense under MPLv2
 
-This is a statement by {{ name of company / name of individual }}
+This is a statement by Christoph Jacob
 that grants permission to relicense its copyrights in the XCFun C++
 library under the Mozilla Public License v2 (MPLv2).
 
-A portion of the commits made by the GitHub handle "{{github username}}", with
-commit author "{{github commit author}}", are copyright of {{ name }} .
+A portion of the commits made by the GitHub handle "chjacob-tubs", with
+commit author "Christoph Jacob", are copyright of Christoph Jacob.
 This document hereby grants the XCFun project team to relicense XCFun,
 including all past, present and future contributions of the author listed above.
 

--- a/RELICENSE/MiroslavIlias.md
+++ b/RELICENSE/MiroslavIlias.md
@@ -4,8 +4,8 @@ This is a statement by Miroslav Ilias
 that grants permission to relicense its copyrights in the XCFun C++
 library under the Mozilla Public License v2 (MPLv2).
 
-A portion of the commits made by the GitHub handle aspgomes, with
-commit author Andre Gomes, are copyright of Andre Severo Pereira Gomes.
+A portion of the commits made by the GitHub handle "miroi" and "miroilias", with
+commit author "Miroslav Ilias", are copyright of Miroslav Ilias.
 This document hereby grants the XCFun project team to relicense XCFun,
 including all past, present and future contributions of the author listed above.
 


### PR DESCRIPTION
Some of the relicensing statements were either not according to the format or actually not stating the intention to relicense. I was too hasty in merging the PRs and thus a new PR to fix the statements. Please @aspgomes @miroi @chjacob-tubs take a look at the diff and apologies for the mix-up!