### PR TITLE
[WIP] Additional overlay for the functional setup.

### DIFF
--- a/include/xcfun.h
+++ b/include/xcfun.h
@@ -113,7 +113,8 @@ enum xc_mode
   int xc_set_fromstring(xc_functional fun, const char *str); // Defines a functional from a string on the form "fun[=value]"
 
     int xc_user_eval_setup(xc_functional fun,
-                           const unsigned int funct_type, // LDA (0), GGA (1), metaGGA (2), taylor (3)
+                           const int order, // order of the derivative requested (order=1 is the xc potential)
+                           const unsigned int func_type, // LDA (0), GGA (1), metaGGA (2), taylor (3)
                            const unsigned int dens_type,  // A (0), N (1), A_B (2), N_S (3)
                            const unsigned int mode_type,  // same as the enum list
                            const unsigned int laplacian,  // 0/1 laplacian no/yes 

--- a/include/xcfun.h
+++ b/include/xcfun.h
@@ -23,9 +23,9 @@ extern "C" {
 enum xc_mode
 {
   XC_MODE_UNSET = 0, // Need to be zero for default initialized structs
-  XC_PARTIAL_DERIVATIVES,
-  XC_POTENTIAL,
-  XC_CONTRACTED,
+  XC_PARTIAL_DERIVATIVES, // XCFun returns partial derivatives of the functional (no contractions)
+  XC_POTENTIAL, // 
+  XC_CONTRACTED, // XC energy density and derivatives
   XC_NR_MODES
 };
   
@@ -40,7 +40,7 @@ enum xc_mode
       XC_N_S,
       // GGA 
       XC_A_GAA,
-      XC_N_GNN,
+      XC_N_GNN, /* GNN scalar product */
       XC_A_B_GAA_GAB_GBB,
       XC_N_S_GNN_GNS_GSS,
       // MetaGGA
@@ -109,6 +109,14 @@ enum xc_mode
   int xc_is_metagga(xc_functional fun);
 
   int xc_set_fromstring(xc_functional fun, const char *str); // Defines a functional from a string on the form "fun[=value]"
+
+    int xc_user_eval_setup(xc_functional fun,
+                           const int funct_type,
+                           const int dens_type,
+                           const int mode_type,
+                           const bool laplacian,
+                           const bool kinetic,
+                           const bool explicit);
 
   // Try to set the functional evaluation vars, mode and order
   // return some combination of XC_E* if an error occurs, else 0.

--- a/include/xcfun.h
+++ b/include/xcfun.h
@@ -113,12 +113,13 @@ enum xc_mode
   int xc_set_fromstring(xc_functional fun, const char *str); // Defines a functional from a string on the form "fun[=value]"
 
     int xc_user_eval_setup(xc_functional fun,
-                           const int funct_type,
-                           const int dens_type,
-                           const int mode_type,
-                           const bool laplacian,
-                           const bool kinetic,
-                           const bool explicit);
+                           const unsigned int funct_type, // LDA (0), GGA (1), metaGGA (2), taylor (3)
+                           const unsigned int dens_type,  // A (0), N (1), A_B (2), N_S (3)
+                           const unsigned int mode_type,  // same as the enum list
+                           const unsigned int laplacian,  // 0/1 laplacian no/yes 
+                           const unsigned int kinetic,    // 0/1 kinetic energy no/yes
+                           const unsigned int current,    // 0/1 current density no/yes
+                           const unsigned int explicit_derivatives);   // 0/1 gamma vs explicit partial derivatives 
 
   // Try to set the functional evaluation vars, mode and order
   // return some combination of XC_E* if an error occurs, else 0.

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -731,7 +731,6 @@ int xc_user_eval_setup(xc_functional fun,
     default:
         xcint_die("xc_user_eval_setup: Invalid vars", bitwise_vars);
     }
-    std::cout << "bitwise_vars " << bitwise_vars << " vars " << vars << std::endl;
     return xc_eval_setup(fun, vars, mode, order);
 }
     

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -635,14 +635,20 @@ void xc_eval(xc_functional_obj *f, const double *input, double *output)
 }
 
 int xc_user_eval_setup(xc_functional fun,
-                       const int funct_type,
-                       const int dens_type,
-                       const int mode_type,
-                       const int laplacian,
-                       const int kinetic,
-                       const int current,
-                       const int expder) {
-    enum xc_vars var = XC_VARS_UNSET; 
+                       const unsigned int funct_type, //
+                       const unsigned int dens_type,
+                       const unsigned int mode_type,
+                       const unsigned int laplacian,
+                       const unsigned int kinetic,
+                       const unsigned int current,
+                       const unsigned int expder) {
+
+    if (func_type > 3 || dens_type > 3 || mode_type > 1 || laplaciam > 1 || kinetic > 1 || current > 1 || expder > 1) {
+        xcint_die("xc_user_eval_setup: invalid input",0);
+    }
+    
+
+    enum xc_vars vars = XC_VARS_UNSET; 
     enum xc_mode mode = XC_MODE_UNSET; 
     switch (mode_type){
     case(1):
@@ -654,114 +660,118 @@ int xc_user_eval_setup(xc_functional fun,
     case(3):
         mode = XC_CONTRACTED;
         break;
+    default:
+        xcint_die("xc_user_eval_setup: Invalid mode", mode_type);
     }
 
-    int bitwise_var = func_type;
-    bitwise_var << 2;
-    bitwise_var += dens_type;
-    bitwise_var << 2;
-    bitwise_var += laplacian;
-    bitwise_var << 1;
-    bitwise_var += kinetic;
-    bitwise_var << 1;
-    bitwise_var += current;
-    bitwise_var << 1;
-    bitwise_var += expder;
+    int bitwise_vars = func_type;
+    bitwise_vars << 2;
+    bitwise_vars += dens_type;
+    bitwise_vars << 2;
+    bitwise_vars += laplacian;
+    bitwise_vars << 1;
+    bitwise_vars += kinetic;
+    bitwise_vars << 1;
+    bitwise_vars += current;
+    bitwise_vars << 1;
+    bitwise_vars += expder;
     
-    switch(bitwise_var){
+    switch(bitwise_vars){
     case(0):
-        var = XC_A;
+        vars = XC_A;
         break;
     case(16):
-        var = XC_N;
+        vars = XC_N;
         break;
     case(32):
-        var = XC_A_B;
+        vars = XC_A_B;
         break;
     case(48):
-        var = XC_N_S;
+        vars = XC_N_S;
         break;
     case(64):
-        var = XC_A_GAA;
+        vars = XC_A_GAA;
         break;
     case(65):
-        var = XC_A_AX_AY_AZ;
+        vars = XC_A_AX_AY_AZ;
         break;
     case(80):
-        var = XC_N_GNN;
+        vars = XC_N_GNN;
         break;
     case(81):
-        var = XC_N_NX_NY_NZ;
+        vars = XC_N_NX_NY_NZ;
         break;
     case(96):
-        var = XC_A_B_GAA_GAB_GBB;
+        vars = XC_A_B_GAA_GAB_GBB;
         break;
     case(97):
-        var = XC_A_B_AX_AY_AZ_BX_BY_BZ;
+        vars = XC_A_B_AX_AY_AZ_BX_BY_BZ;
         break;
     case(112):
-        var = XC_N_S_GNN_GNS_GSS;
+        vars = XC_N_S_GNN_GNS_GSS;
         break;
     case(113):
-        var = XC_N_S_NX_NY_NZ_SX_SY_SZ;
+        vars = XC_N_S_NX_NY_NZ_SX_SY_SZ;
         break;
     case(132):
-        var = XC_A_GAA_TAUA;
+        vars = XC_A_GAA_TAUA;
         break;
     case(133):
-        var = XC_A_AX_AY_AZ_TAUA;
+        vars = XC_A_AX_AY_AZ_TAUA;
         break;
     case(136):
-        var = XC_A_GAA_LAPA;
+        vars = XC_A_GAA_LAPA;
         break;
     case(148):
-        var = XC_N_GNN_TAUN;
+        vars = XC_N_GNN_TAUN;
         break;
     case(149):
-        var = XC_N_NX_NY_NZ_TAUN;
+        vars = XC_N_NX_NY_NZ_TAUN;
         break;
     case(152):
-        var = XC_N_GNN_LAPN;
+        vars = XC_N_GNN_LAPN;
         break;
     case(164):
-        var = XC_A_B_GAA_GAB_GBB_TAUA_TAUB;
+        vars = XC_A_B_GAA_GAB_GBB_TAUA_TAUB;
         break;
     case(165):
-        var = XC_A_B_AX_AY_AZ_BX_BY_BZ_TAUA_TAUB;
+        vars = XC_A_B_AX_AY_AZ_BX_BY_BZ_TAUA_TAUB;
         break;
     case(168):
-        var = XC_A_B_GAA_GAB_GBB_LAPA_LAPB;
+        vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB;
         break;
     case(172):
-        var = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB;
+        vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB;
         break;
     case(174):
-        var = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB_JPAA_JPBB;
+        vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB_JPAA_JPBB;
         break;
     case(180):
-        var = XC_N_S_GNN_GNS_GSS_TAUN_TAUS;
+        vars = XC_N_S_GNN_GNS_GSS_TAUN_TAUS;
         break;
     case(181):
-        var = XC_N_S_NX_NY_NZ_SX_SY_SZ_TAUN_TAUS;
+        vars = XC_N_S_NX_NY_NZ_SX_SY_SZ_TAUN_TAUS;
         break;
     case(184):
-        var = XC_N_S_GNN_GNS_GSS_LAPN_LAPS;
+        vars = XC_N_S_GNN_GNS_GSS_LAPN_LAPS;
         break;
     case(188):
-        var = XC_N_S_GNN_GNS_GSS_LAPN_LAPS_TAUN_TAUS;
+        vars = XC_N_S_GNN_GNS_GSS_LAPN_LAPS_TAUN_TAUS;
         break;
     case(192):
-        var = XC_A_2ND_TAYLOR;
+        vars = XC_A_2ND_TAYLOR;
         break;
     case(208):
-        var = XC_N_2ND_TAYLOR;
+        vars = XC_N_2ND_TAYLOR;
         break;
     case(224):
-        var = XC_A_B_2ND_TAYLOR;
+        vars = XC_A_B_2ND_TAYLOR;
         break;
     case(240):
-        var = XC_N_S_2ND_TAYLOR;
+        vars = XC_N_S_2ND_TAYLOR;
         break;
+    default:
+        xcint_die("xc_user_eval_setup: Invalid vars", bitwise_vars);
     }
     return xc_eval_setup(fun, vars, mode, order);
 }

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -635,31 +635,26 @@ void xc_eval(xc_functional_obj *f, const double *input, double *output)
 }
 
 int xc_user_eval_setup(xc_functional fun,
-                       const unsigned int funct_type, //
-                       const unsigned int dens_type,
-                       const unsigned int mode_type,
-                       const unsigned int laplacian,
-                       const unsigned int kinetic,
-                       const unsigned int current,
-                       const unsigned int expder) {
+                       const unsigned int funct_type, // LDA (0), GGA (1), metaGGA (2), taylor (3)
+                       const unsigned int dens_type,  // A (0), N (1), A_B (2), N_S (3)
+                       const unsigned int mode_type,  // same as the enum list
+                       const unsigned int laplacian,  // 0/1 laplacian no/yes 
+                       const unsigned int kinetic,    // 0/1 kinetic energy no/yes
+                       const unsigned int current,    // 0/1 current density no/yes
+                       const unsigned int explicit_derivatives) {   // 0/1 gamma vs explicit partial derivatives 
 
-    if (func_type > 3 || dens_type > 3 || mode_type > 1 || laplaciam > 1 || kinetic > 1 || current > 1 || expder > 1) {
-        xcint_die("xc_user_eval_setup: invalid input",0);
+    if (func_type > 3 || dens_type > 3 || mode_type > 3 || laplaciam > 1 || kinetic > 1 || current > 1 || expder > 1) {
+        xcint_die("xc_user_eval_setup: invalid input",-1);
     }
     
 
     enum xc_vars vars = XC_VARS_UNSET; 
-    enum xc_mode mode = XC_MODE_UNSET; 
+    enum xc_mode mode = XC_MODE_UNSET;
+    
     switch (mode_type){
-    case(1):
-        mode = XC_PARTIAL_DERIVATIVES;
-        break;
-    case(2):
-        mode = XC_POTENTIAL;
-        break;
-    case(3):
-        mode = XC_CONTRACTED;
-        break;
+    case(1): mode = XC_PARTIAL_DERIVATIVES; break;
+    case(2): mode = XC_POTENTIAL;           break;
+    case(3): mode = XC_CONTRACTED;          break;
     default:
         xcint_die("xc_user_eval_setup: Invalid mode", mode_type);
     }
@@ -677,99 +672,37 @@ int xc_user_eval_setup(xc_functional fun,
     bitwise_vars += expder;
     
     switch(bitwise_vars){
-    case(0):
-        vars = XC_A;
-        break;
-    case(16):
-        vars = XC_N;
-        break;
-    case(32):
-        vars = XC_A_B;
-        break;
-    case(48):
-        vars = XC_N_S;
-        break;
-    case(64):
-        vars = XC_A_GAA;
-        break;
-    case(65):
-        vars = XC_A_AX_AY_AZ;
-        break;
-    case(80):
-        vars = XC_N_GNN;
-        break;
-    case(81):
-        vars = XC_N_NX_NY_NZ;
-        break;
-    case(96):
-        vars = XC_A_B_GAA_GAB_GBB;
-        break;
-    case(97):
-        vars = XC_A_B_AX_AY_AZ_BX_BY_BZ;
-        break;
-    case(112):
-        vars = XC_N_S_GNN_GNS_GSS;
-        break;
-    case(113):
-        vars = XC_N_S_NX_NY_NZ_SX_SY_SZ;
-        break;
-    case(132):
-        vars = XC_A_GAA_TAUA;
-        break;
-    case(133):
-        vars = XC_A_AX_AY_AZ_TAUA;
-        break;
-    case(136):
-        vars = XC_A_GAA_LAPA;
-        break;
-    case(148):
-        vars = XC_N_GNN_TAUN;
-        break;
-    case(149):
-        vars = XC_N_NX_NY_NZ_TAUN;
-        break;
-    case(152):
-        vars = XC_N_GNN_LAPN;
-        break;
-    case(164):
-        vars = XC_A_B_GAA_GAB_GBB_TAUA_TAUB;
-        break;
-    case(165):
-        vars = XC_A_B_AX_AY_AZ_BX_BY_BZ_TAUA_TAUB;
-        break;
-    case(168):
-        vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB;
-        break;
-    case(172):
-        vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB;
-        break;
-    case(174):
-        vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB_JPAA_JPBB;
-        break;
-    case(180):
-        vars = XC_N_S_GNN_GNS_GSS_TAUN_TAUS;
-        break;
-    case(181):
-        vars = XC_N_S_NX_NY_NZ_SX_SY_SZ_TAUN_TAUS;
-        break;
-    case(184):
-        vars = XC_N_S_GNN_GNS_GSS_LAPN_LAPS;
-        break;
-    case(188):
-        vars = XC_N_S_GNN_GNS_GSS_LAPN_LAPS_TAUN_TAUS;
-        break;
-    case(192):
-        vars = XC_A_2ND_TAYLOR;
-        break;
-    case(208):
-        vars = XC_N_2ND_TAYLOR;
-        break;
-    case(224):
-        vars = XC_A_B_2ND_TAYLOR;
-        break;
-    case(240):
-        vars = XC_N_S_2ND_TAYLOR;
-        break;
+    case(0):    vars = XC_A;                                             break;
+    case(16):   vars = XC_N;                                             break;
+    case(32):   vars = XC_A_B;                                           break;
+    case(48):   vars = XC_N_S;                                           break;
+    case(64):   vars = XC_A_GAA;                                         break;
+    case(65):   vars = XC_A_AX_AY_AZ;                                    break;
+    case(80):   vars = XC_N_GNN;                                         break;
+    case(81):   vars = XC_N_NX_NY_NZ;                                    break;
+    case(96):   vars = XC_A_B_GAA_GAB_GBB;                               break;
+    case(97):   vars = XC_A_B_AX_AY_AZ_BX_BY_BZ;                         break;
+    case(112):  vars = XC_N_S_GNN_GNS_GSS;                               break;
+    case(113):  vars = XC_N_S_NX_NY_NZ_SX_SY_SZ;                         break;
+    case(132):  vars = XC_A_GAA_TAUA;                                    break;
+    case(133):  vars = XC_A_AX_AY_AZ_TAUA;                               break;
+    case(136):  vars = XC_A_GAA_LAPA;                                    break;
+    case(148):  vars = XC_N_GNN_TAUN;                                    break;
+    case(149):  vars = XC_N_NX_NY_NZ_TAUN;                               break;
+    case(152):  vars = XC_N_GNN_LAPN;                                    break;
+    case(164):  vars = XC_A_B_GAA_GAB_GBB_TAUA_TAUB;                     break;
+    case(165):  vars = XC_A_B_AX_AY_AZ_BX_BY_BZ_TAUA_TAUB;               break;
+    case(168):  vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB;                     break;
+    case(172):  vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB;           break;
+    case(174):  vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB_JPAA_JPBB; break;
+    case(180):  vars = XC_N_S_GNN_GNS_GSS_TAUN_TAUS;                     break;
+    case(181):  vars = XC_N_S_NX_NY_NZ_SX_SY_SZ_TAUN_TAUS;               break;
+    case(184):  vars = XC_N_S_GNN_GNS_GSS_LAPN_LAPS;                     break;
+    case(188):  vars = XC_N_S_GNN_GNS_GSS_LAPN_LAPS_TAUN_TAUS;           break;
+    case(192):  vars = XC_A_2ND_TAYLOR;                                  break;
+    case(208):  vars = XC_N_2ND_TAYLOR;                                  break;
+    case(224):  vars = XC_A_B_2ND_TAYLOR;                                break;
+    case(240):  vars = XC_N_S_2ND_TAYLOR;                                break;
     default:
         xcint_die("xc_user_eval_setup: Invalid vars", bitwise_vars);
     }

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -1,6 +1,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <iostream>
 #include "xcint.hpp"
 
 xc_functional xc_new_functional_not_macro(int api_version)
@@ -699,7 +700,7 @@ int xc_user_eval_setup(xc_functional fun,
     case(0):    vars = XC_A;                                             break;  // 0  0  |  0  0  |  0  |  0  |  0  |  0
     case(16):   vars = XC_N;                                             break;  // 0  0  |  0  1  |  0  |  0  |  0  |  0
     case(32):   vars = XC_A_B;                                           break;  // 0  0  |  1  0  |  0  |  0  |  0  |  0
-    case(48):   vars = XC_N_S;                                           break;  // 0  0  |  1  0  |  0  |  0  |  0  |  0
+    case(48):   vars = XC_N_S;                                           break;  // 0  0  |  1  1  |  0  |  0  |  0  |  0
     case(64):   vars = XC_A_GAA;                                         break;  // 0  1  |  0  0  |  0  |  0  |  0  |  0
     case(65):   vars = XC_A_AX_AY_AZ;                                    break;  // 0  1  |  0  0  |  0  |  0  |  0  |  1
     case(80):   vars = XC_N_GNN;                                         break;  // 0  1  |  0  1  |  0  |  0  |  0  |  0
@@ -730,6 +731,7 @@ int xc_user_eval_setup(xc_functional fun,
     default:
         xcint_die("xc_user_eval_setup: Invalid vars", bitwise_vars);
     }
+    std::cout << "bitwise_vars " << bitwise_vars << " vars " << vars << std::endl;
     return xc_eval_setup(fun, vars, mode, order);
 }
     

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -635,7 +635,8 @@ void xc_eval(xc_functional_obj *f, const double *input, double *output)
 }
 
 int xc_user_eval_setup(xc_functional fun,
-                       const unsigned int funct_type, // LDA (0), GGA (1), metaGGA (2), taylor (3)
+                       const int order,
+                       const unsigned int func_type, // LDA (0), GGA (1), metaGGA (2), taylor (3)
                        const unsigned int dens_type,  // A (0), N (1), A_B (2), N_S (3)
                        const unsigned int mode_type,  // same as the enum list
                        const unsigned int laplacian,  // 0/1 laplacian no/yes 
@@ -643,7 +644,7 @@ int xc_user_eval_setup(xc_functional fun,
                        const unsigned int current,    // 0/1 current density no/yes
                        const unsigned int explicit_derivatives) {   // 0/1 gamma vs explicit partial derivatives 
 
-    if (func_type > 3 || dens_type > 3 || mode_type > 3 || laplaciam > 1 || kinetic > 1 || current > 1 || explicit_derivatives > 1) {
+    if (func_type > 3 || dens_type > 3 || mode_type > 3 || laplacian > 1 || kinetic > 1 || current > 1 || explicit_derivatives > 1) {
         xcint_die("xc_user_eval_setup: invalid input",-1);
     }
     
@@ -686,46 +687,46 @@ int xc_user_eval_setup(xc_functional fun,
                                    1     explicit partial derivatives
      */
 
-    func_type << 6;
-    dens_type << 4;
-    laplacian << 3;
-    kinetic   << 2;
-    current   << 1;
-
-    int bitwise_vars = func_type + dens_type + laplacian + kinetic + current + explicit_derivatives;
+    int bitwise_vars = 0;
+    bitwise_vars += func_type << 6;       // 0 64 128 192
+    bitwise_vars += dens_type << 4;       // 0 16  32  48
+    bitwise_vars += laplacian << 3;       // 0  8
+    bitwise_vars += kinetic   << 2;       // 0  4
+    bitwise_vars += current   << 1;       // 0  2
+    bitwise_vars += explicit_derivatives; // 0  1
 
     switch(bitwise_vars){
-    case(0):    vars = XC_A;                                             break;
-    case(16):   vars = XC_N;                                             break;
-    case(32):   vars = XC_A_B;                                           break;
-    case(48):   vars = XC_N_S;                                           break;
-    case(64):   vars = XC_A_GAA;                                         break;
-    case(65):   vars = XC_A_AX_AY_AZ;                                    break;
-    case(80):   vars = XC_N_GNN;                                         break;
-    case(81):   vars = XC_N_NX_NY_NZ;                                    break;
-    case(96):   vars = XC_A_B_GAA_GAB_GBB;                               break;
-    case(97):   vars = XC_A_B_AX_AY_AZ_BX_BY_BZ;                         break;
-    case(112):  vars = XC_N_S_GNN_GNS_GSS;                               break;
-    case(113):  vars = XC_N_S_NX_NY_NZ_SX_SY_SZ;                         break;
-    case(132):  vars = XC_A_GAA_TAUA;                                    break;
-    case(133):  vars = XC_A_AX_AY_AZ_TAUA;                               break;
-    case(136):  vars = XC_A_GAA_LAPA;                                    break;
-    case(148):  vars = XC_N_GNN_TAUN;                                    break;
-    case(149):  vars = XC_N_NX_NY_NZ_TAUN;                               break;
-    case(152):  vars = XC_N_GNN_LAPN;                                    break;
-    case(164):  vars = XC_A_B_GAA_GAB_GBB_TAUA_TAUB;                     break;
-    case(165):  vars = XC_A_B_AX_AY_AZ_BX_BY_BZ_TAUA_TAUB;               break;
-    case(168):  vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB;                     break;
-    case(172):  vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB;           break;
-    case(174):  vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB_JPAA_JPBB; break;
-    case(180):  vars = XC_N_S_GNN_GNS_GSS_TAUN_TAUS;                     break;
-    case(181):  vars = XC_N_S_NX_NY_NZ_SX_SY_SZ_TAUN_TAUS;               break;
-    case(184):  vars = XC_N_S_GNN_GNS_GSS_LAPN_LAPS;                     break;
-    case(188):  vars = XC_N_S_GNN_GNS_GSS_LAPN_LAPS_TAUN_TAUS;           break;
-    case(192):  vars = XC_A_2ND_TAYLOR;                                  break;
-    case(208):  vars = XC_N_2ND_TAYLOR;                                  break;
-    case(224):  vars = XC_A_B_2ND_TAYLOR;                                break;
-    case(240):  vars = XC_N_S_2ND_TAYLOR;                                break;
+    case(0):    vars = XC_A;                                             break;  // 0  0  |  0  0  |  0  |  0  |  0  |  0
+    case(16):   vars = XC_N;                                             break;  // 0  0  |  0  1  |  0  |  0  |  0  |  0
+    case(32):   vars = XC_A_B;                                           break;  // 0  0  |  1  0  |  0  |  0  |  0  |  0
+    case(48):   vars = XC_N_S;                                           break;  // 0  0  |  1  0  |  0  |  0  |  0  |  0
+    case(64):   vars = XC_A_GAA;                                         break;  // 0  1  |  0  0  |  0  |  0  |  0  |  0
+    case(65):   vars = XC_A_AX_AY_AZ;                                    break;  // 0  1  |  0  0  |  0  |  0  |  0  |  1
+    case(80):   vars = XC_N_GNN;                                         break;  // 0  1  |  0  1  |  0  |  0  |  0  |  0
+    case(81):   vars = XC_N_NX_NY_NZ;                                    break;  // 0  1  |  0  1  |  0  |  0  |  0  |  1
+    case(96):   vars = XC_A_B_GAA_GAB_GBB;                               break;  // 0  1  |  1  0  |  0  |  0  |  0  |  0
+    case(97):   vars = XC_A_B_AX_AY_AZ_BX_BY_BZ;                         break;  // 0  1  |  1  0  |  0  |  0  |  0  |  1
+    case(112):  vars = XC_N_S_GNN_GNS_GSS;                               break;  // 0  1  |  1  1  |  0  |  0  |  0  |  0
+    case(113):  vars = XC_N_S_NX_NY_NZ_SX_SY_SZ;                         break;  // 0  1  |  1  1  |  0  |  0  |  0  |  1
+    case(132):  vars = XC_A_GAA_TAUA;                                    break;  // 1  0  |  0  0  |  0  |  1  |  0  |  0
+    case(133):  vars = XC_A_AX_AY_AZ_TAUA;                               break;  // 1  0  |  0  0  |  0  |  1  |  0  |  1
+    case(136):  vars = XC_A_GAA_LAPA;                                    break;  // 1  0  |  0  0  |  1  |  0  |  0  |  0
+    case(148):  vars = XC_N_GNN_TAUN;                                    break;  // 1  0  |  0  1  |  0  |  1  |  0  |  0
+    case(149):  vars = XC_N_NX_NY_NZ_TAUN;                               break;  // 1  0  |  0  1  |  0  |  1  |  0  |  1
+    case(152):  vars = XC_N_GNN_LAPN;                                    break;  // 1  0  |  0  1  |  1  |  0  |  0  |  0
+    case(164):  vars = XC_A_B_GAA_GAB_GBB_TAUA_TAUB;                     break;  // 1  0  |  1  0  |  0  |  1  |  0  |  0
+    case(165):  vars = XC_A_B_AX_AY_AZ_BX_BY_BZ_TAUA_TAUB;               break;  // 1  0  |  1  0  |  0  |  1  |  0  |  1
+    case(168):  vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB;                     break;  // 1  0  |  1  0  |  1  |  0  |  0  |  0
+    case(172):  vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB;           break;  // 1  0  |  1  0  |  1  |  1  |  0  |  0
+    case(174):  vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB_JPAA_JPBB; break;  // 1  0  |  1  0  |  1  |  1  |  1  |  0
+    case(180):  vars = XC_N_S_GNN_GNS_GSS_TAUN_TAUS;                     break;  // 1  0  |  1  1  |  0  |  1  |  0  |  0
+    case(181):  vars = XC_N_S_NX_NY_NZ_SX_SY_SZ_TAUN_TAUS;               break;  // 1  0  |  1  1  |  0  |  1  |  0  |  1
+    case(184):  vars = XC_N_S_GNN_GNS_GSS_LAPN_LAPS;                     break;  // 1  0  |  1  1  |  1  |  0  |  0  |  0
+    case(188):  vars = XC_N_S_GNN_GNS_GSS_LAPN_LAPS_TAUN_TAUS;           break;  // 1  0  |  1  1  |  1  |  1  |  0  |  0
+    case(192):  vars = XC_A_2ND_TAYLOR;                                  break;  // 1  1  |  0  0  |  0  |  0  |  0  |  0
+    case(208):  vars = XC_N_2ND_TAYLOR;                                  break;  // 1  1  |  0  1  |  0  |  0  |  0  |  0
+    case(224):  vars = XC_A_B_2ND_TAYLOR;                                break;  // 1  1  |  1  0  |  0  |  0  |  0  |  0
+    case(240):  vars = XC_N_S_2ND_TAYLOR;                                break;  // 1  1  |  1  1  |  0  |  0  |  0  |  0
     default:
         xcint_die("xc_user_eval_setup: Invalid vars", bitwise_vars);
     }
@@ -888,3 +889,4 @@ int xc_is_metagga(xc_functional fun)
     return (fun->depends & (XC_LAPLACIAN | XC_KINETIC));
 }
 
+//int xc_needs_one_dens(xc_functional fun)

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -634,6 +634,139 @@ void xc_eval(xc_functional_obj *f, const double *input, double *output)
     }
 }
 
+int xc_user_eval_setup(xc_functional fun,
+                       const int funct_type,
+                       const int dens_type,
+                       const int mode_type,
+                       const int laplacian,
+                       const int kinetic,
+                       const int current,
+                       const int expder) {
+    enum xc_vars var = XC_VARS_UNSET; 
+    enum xc_mode mode = XC_MODE_UNSET; 
+    switch (mode_type){
+    case(1):
+        mode = XC_PARTIAL_DERIVATIVES;
+        break;
+    case(2):
+        mode = XC_POTENTIAL;
+        break;
+    case(3):
+        mode = XC_CONTRACTED;
+        break;
+    }
+
+    int bitwise_var = func_type;
+    bitwise_var << 2;
+    bitwise_var += dens_type;
+    bitwise_var << 2;
+    bitwise_var += laplacian;
+    bitwise_var << 1;
+    bitwise_var += kinetic;
+    bitwise_var << 1;
+    bitwise_var += current;
+    bitwise_var << 1;
+    bitwise_var += expder;
+    
+    switch(bitwise_var){
+    case(0):
+        var = XC_A;
+        break;
+    case(16):
+        var = XC_N;
+        break;
+    case(32):
+        var = XC_A_B;
+        break;
+    case(48):
+        var = XC_N_S;
+        break;
+    case(64):
+        var = XC_A_GAA;
+        break;
+    case(65):
+        var = XC_A_AX_AY_AZ;
+        break;
+    case(80):
+        var = XC_N_GNN;
+        break;
+    case(81):
+        var = XC_N_NX_NY_NZ;
+        break;
+    case(96):
+        var = XC_A_B_GAA_GAB_GBB;
+        break;
+    case(97):
+        var = XC_A_B_AX_AY_AZ_BX_BY_BZ;
+        break;
+    case(112):
+        var = XC_N_S_GNN_GNS_GSS;
+        break;
+    case(113):
+        var = XC_N_S_NX_NY_NZ_SX_SY_SZ;
+        break;
+    case(132):
+        var = XC_A_GAA_TAUA;
+        break;
+    case(133):
+        var = XC_A_AX_AY_AZ_TAUA;
+        break;
+    case(136):
+        var = XC_A_GAA_LAPA;
+        break;
+    case(148):
+        var = XC_N_GNN_TAUN;
+        break;
+    case(149):
+        var = XC_N_NX_NY_NZ_TAUN;
+        break;
+    case(152):
+        var = XC_N_GNN_LAPN;
+        break;
+    case(164):
+        var = XC_A_B_GAA_GAB_GBB_TAUA_TAUB;
+        break;
+    case(165):
+        var = XC_A_B_AX_AY_AZ_BX_BY_BZ_TAUA_TAUB;
+        break;
+    case(168):
+        var = XC_A_B_GAA_GAB_GBB_LAPA_LAPB;
+        break;
+    case(172):
+        var = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB;
+        break;
+    case(174):
+        var = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB_JPAA_JPBB;
+        break;
+    case(180):
+        var = XC_N_S_GNN_GNS_GSS_TAUN_TAUS;
+        break;
+    case(181):
+        var = XC_N_S_NX_NY_NZ_SX_SY_SZ_TAUN_TAUS;
+        break;
+    case(184):
+        var = XC_N_S_GNN_GNS_GSS_LAPN_LAPS;
+        break;
+    case(188):
+        var = XC_N_S_GNN_GNS_GSS_LAPN_LAPS_TAUN_TAUS;
+        break;
+    case(192):
+        var = XC_A_2ND_TAYLOR;
+        break;
+    case(208):
+        var = XC_N_2ND_TAYLOR;
+        break;
+    case(224):
+        var = XC_A_B_2ND_TAYLOR;
+        break;
+    case(240):
+        var = XC_N_S_2ND_TAYLOR;
+        break;
+    }
+    return xc_eval_setup(fun, vars, mode, order);
+}
+    
+        
 int xc_eval_setup(xc_functional fun,
 		  enum xc_vars vars,
 		  enum xc_mode mode,

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -643,7 +643,7 @@ int xc_user_eval_setup(xc_functional fun,
                        const unsigned int current,    // 0/1 current density no/yes
                        const unsigned int explicit_derivatives) {   // 0/1 gamma vs explicit partial derivatives 
 
-    if (func_type > 3 || dens_type > 3 || mode_type > 3 || laplaciam > 1 || kinetic > 1 || current > 1 || expder > 1) {
+    if (func_type > 3 || dens_type > 3 || mode_type > 3 || laplaciam > 1 || kinetic > 1 || current > 1 || explicit_derivatives > 1) {
         xcint_die("xc_user_eval_setup: invalid input",-1);
     }
     
@@ -659,18 +659,41 @@ int xc_user_eval_setup(xc_functional fun,
         xcint_die("xc_user_eval_setup: Invalid mode", mode_type);
     }
 
-    int bitwise_vars = func_type;
-    bitwise_vars << 2;
-    bitwise_vars += dens_type;
-    bitwise_vars << 2;
-    bitwise_vars += laplacian;
-    bitwise_vars << 1;
-    bitwise_vars += kinetic;
-    bitwise_vars << 1;
-    bitwise_vars += current;
-    bitwise_vars << 1;
-    bitwise_vars += expder;
-    
+
+    /* Bit encoding of information 
+       7   6   5   4   3   2   1   0
+    ------------------------------------------------------------------
+       0   0                             LDA
+       0   1                             GGA
+       1   0                             metaGGA
+       1   1                             Taylor
+    ------------------------------------------------------------------
+               0   0                     alpha density
+               0   1                     n density
+               1   0                     anpha and beta densities
+               1   1                     n and s density
+    ------------------------------------------------------------------
+                       0                 no laplacian 
+                       1                 laplacian required
+    ------------------------------------------------------------------
+                           0             no kinetic energy
+                           1             kinetic energy required
+    ------------------------------------------------------------------
+                               0         no current density required
+                               1         current density required
+    ------------------------------------------------------------------
+                                   0     gamma-type partial derivatives
+                                   1     explicit partial derivatives
+     */
+
+    func_type << 6;
+    dens_type << 4;
+    laplacian << 3;
+    kinetic   << 2;
+    current   << 1;
+
+    int bitwise_vars = func_type + dens_type + laplacian + kinetic + current + explicit_derivatives;
+
     switch(bitwise_vars){
     case(0):    vars = XC_A;                                             break;
     case(16):   vars = XC_N;                                             break;


### PR DESCRIPTION
The new routine takes a few integers as input. It combines them with bit manipulations. The final value corresponds to a unique `eval xc_vars`. Another integer fixes `eval xc_mode`.
The return statement calls the original `xc_eval_setup`.

I have not tested it yet. Feedback welcome :-)

Still missing: 
- sanity checks for the input integers
- graceful error exit in case the requested combination is not available.