### PR TITLE
C/C++ standards flags

### DIFF
--- a/cmake/custom/compilers/CFlags.cmake
+++ b/cmake/custom/compilers/CFlags.cmake
@@ -1,15 +1,21 @@
-# C99
-set(CMAKE_C_STANDARD 99)
-set(CMAKE_C_EXTENSIONS OFF)
-set(CMAKE_C_STANDARD_REQUIRED ON)
+include(SetCompilerFlag)
 
 set(XCFun_C_FLAGS)
 set(XCFun_C_FLAGS_DEBUG)
 set(XCFun_C_FLAGS_RELEASE)
 set(XCFun_C_FLAGS_COVERAGE)
 
+# C99
+set_compiler_flag(
+  RESULT c99_flag
+  LANGUAGE C
+  REQUIRED
+  FLAGS "-std=c99;-c99;-c9x"
+  )
+
 if(CMAKE_C_COMPILER_ID MATCHES GNU)
   list(APPEND XCFun_C_FLAGS
+    "${c99_flag}"
     "-ffloat-store"
     "-m64"
     )
@@ -38,6 +44,7 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
   list(APPEND XCFun_C_FLAGS
+    "${c99_flag}"
     "-m64"
     "-Qunused-arguments"
     "-fcolor-diagnostics"
@@ -64,6 +71,7 @@ endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES Intel)
   list(APPEND XCFun_C_FLAGS
+    "${c99_flag}"
     "-g"
     "-wd981"
     "-wd279"
@@ -88,18 +96,19 @@ endif ()
 
 if(CMAKE_C_COMPILER_ID MATCHES PGI)
   list(APPEND XCFun_C_FLAGS
+    "${c99_flag}"
     "-Mpreprocess"
     )
   list(APPEND XCFun_C_FLAGS_DEBUG
     "-g"
     "-O0"
-    "-c9x"
     )
   list(APPEND XCFun_C_FLAGS_RELEASE
     "-O3"
     "-fast"
     "-Munroll"
     "-Mvect=idiom"
-    "-c9x"
     )
 endif()
+
+message(STATUS "C compiler flags       : ${CMAKE_C_FLAGS} ${XCFun_C_FLAGS} ${CMAKE_C_FLAGS_${CMAKE_BUILD_TYPE}} ${XCFun_C_FLAGS_${CMAKE_BUILD_TYPE}}")

--- a/cmake/custom/compilers/CFlags.cmake
+++ b/cmake/custom/compilers/CFlags.cmake
@@ -68,7 +68,6 @@ if(CMAKE_C_COMPILER_ID MATCHES Intel)
     "-wd981"
     "-wd279"
     "-wd383"
-    "-vec-report0"
     "-wd1572"
     "-wd1777"
     "-restrict"

--- a/cmake/custom/compilers/CXXFlags.cmake
+++ b/cmake/custom/compilers/CXXFlags.cmake
@@ -77,7 +77,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
     "-wd981"
     "-wd279"
     "-wd383"
-    "-vec-report0"
     "-wd1572"
     "-wd177"
     "-fno-rtti"

--- a/cmake/custom/compilers/CXXFlags.cmake
+++ b/cmake/custom/compilers/CXXFlags.cmake
@@ -1,15 +1,21 @@
-# C++11
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+include(SetCompilerFlag)
 
 set(XCFun_CXX_FLAGS)
 set(XCFun_CXX_FLAGS_DEBUG)
 set(XCFun_CXX_FLAGS_RELEASE)
 set(XCFun_CXX_FLAGS_COVERAGE)
 
+# C++11
+set_compiler_flag(
+  RESULT cxx11_flag
+  LANGUAGE CXX
+  REQUIRED
+  FLAGS "-std=c++11;-std=c++0x;--c++11;--c++0x"
+  )
+
 if(CMAKE_CXX_COMPILER_ID MATCHES GNU)
   list(APPEND XCFun_CXX_FLAGS
+    "${cxx11_flag}"
     "-ffloat-store"
     "-fno-rtti"
     "-fno-exceptions"
@@ -42,6 +48,7 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
   list(APPEND XCFun_CXX_FLAGS
+    "${cxx11_flag}"
     "-fno-rtti"
     "-fno-exceptions"
     "-m64"
@@ -73,6 +80,7 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
   list(APPEND XCFun_CXX_FLAGS
+    "${cxx11_flag}"
     "-g"
     "-wd981"
     "-wd279"
@@ -95,6 +103,7 @@ endif ()
 if(CMAKE_CXX_COMPILER_ID MATCHES PGI)
   #236 suppress assert warnings and 175 suppress subscript out of range warning /SR
   list(APPEND XCFun_CXX_FLAGS
+    "${cxx11_flag}"
     "-Mpreprocess"
     "--diag_suppress 236"
     "--diag_suppress 175"
@@ -102,13 +111,13 @@ if(CMAKE_CXX_COMPILER_ID MATCHES PGI)
   list(APPEND XCFun_CXX_FLAGS_DEBUG
     "-g"
     "-O0"
-    "-c9x"
     )
   list(APPEND XCFun_CXX_FLAGS_RELEASE
     "-O3"
     "-fast"
     "-Munroll"
     "-Mvect=idiom"
-    "-c9x"
     )
 endif()
+
+message(STATUS "C++ compiler flags     : ${CMAKE_CXX_FLAGS} ${XCFun_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}} ${XCFun_CXX_FLAGS_${CMAKE_BUILD_TYPE}}")

--- a/cmake/custom/compilers/FortranFlags.cmake
+++ b/cmake/custom/compilers/FortranFlags.cmake
@@ -63,7 +63,6 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES PGI)
     "-Mipa=fast"
     "-Munroll"
     "-Mvect=idiom"
-    "-c9x"
     )
 endif()
 
@@ -77,3 +76,5 @@ if(ENABLE_CODE_COVERAGE)
     message(FATAL_ERROR "Code coverage analysis requires the GNU Fortran compiler!")
   endif()
 endif()
+
+message(STATUS "Fortran compiler flags : ${CMAKE_Fortran_FLAGS} ${XCFun_Fortran_FLAGS} ${CMAKE_Fortran_FLAGS_${CMAKE_BUILD_TYPE}} ${XCFun_Fortran_FLAGS_${CMAKE_BUILD_TYPE}}")

--- a/cmake/custom/compilers/SetCompilerFlag.cmake
+++ b/cmake/custom/compilers/SetCompilerFlag.cmake
@@ -30,45 +30,36 @@ function(set_compiler_flag)
     ${ARGN}
   )
 
-  # build a list of flags from the arguments
-  set(_list_of_flags)
-  # also figure out whether the function is required to find a flag
-  set(_flag_is_required FALSE)
-  foreach(_arg ${ARGN})
-    string(TOUPPER "${_arg}" _arg_uppercase)
-    if(_arg_uppercase STREQUAL "REQUIRED")
-      set(_flag_is_required TRUE)
-    else()
-      list(APPEND _list_of_flags "${_arg}")
-    endif()
-  endforeach()
-
+  # Silently check compiler flags
+  set(restore_CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET})
+  set(CMAKE_REQUIRED_QUIET TRUE)
   set(_flag_found FALSE)
   # loop over all flags, try to find the first which works
-  foreach(flag ${_list_of_flags})
-
+  foreach(flag IN LISTS set_compiler_flag_FLAGS)
     unset(_flag_works CACHE)
-    if(_lang STREQUAL "C")
+    if(${set_compiler_flag_LANGUAGE} STREQUAL "C")
       check_c_compiler_flag("${flag}" _flag_works)
-    elseif(_lang STREQUAL "CXX")
+    elseif(${set_compiler_flag_LANGUAGE} STREQUAL "CXX")
       check_cxx_compiler_flag("${flag}" _flag_works)
-    elseif(_lang STREQUAL "Fortran")
+    elseif(${set_compiler_flag_LANGUAGE} STREQUAL "Fortran")
       check_Fortran_compiler_flag("${flag}" _flag_works)
     else()
-      message(FATAL_ERROR "Unknown language in set_compiler_flag: ${_lang}")
+      message(FATAL_ERROR "Unknown language in set_compiler_flag: ${set_compiler_flag_LANGUAGE}")
     endif()
 
-    # if the flag works, use it, and exit
+    # if the flag works, use it, and exit loop
     # otherwise try next flag
     if(_flag_works)
-      set(${_result} "${flag}" PARENT_SCOPE)
+      set(${set_compiler_flag_RESULT} "${flag}" PARENT_SCOPE)
       set(_flag_found TRUE)
       break()
     endif()
   endforeach()
 
   # raise an error if no flag was found
-  if(_flag_is_required AND NOT _flag_found)
+  if(${set_compiler_flag_REQUIRED} AND NOT _flag_found)
     message(FATAL_ERROR "None of the required flags were supported")
   endif()
+  # Restore CMAKE_REQUIRED_QUIET
+  set(CMAKE_REQUIRED_QUIET ${restore_CMAKE_REQUIRED_QUIET})
 endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,14 +20,12 @@ target_compile_options(xcfun-objlib
 target_compile_definitions(xcfun-objlib
   PUBLIC
     XCFun_EXPORTS
-    "$<$<BOOL:${ENABLE_64BIT_INTEGERS}>:XCFun_FORTRAN_INT=long long int>"
     XC_MAX_ORDER=${XCFun_XC_MAX_ORDER}
   )
 target_include_directories(xcfun-objlib
-  PUBLIC
+  PRIVATE
     ${PROJECT_SOURCE_DIR}/api
     ${PROJECT_BINARY_DIR}/include
-  PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
   )
 target_include_directories(xcfun-objlib
@@ -38,21 +36,46 @@ target_include_directories(xcfun-objlib
 
 target_sources(xcfun-objlib
   PRIVATE
-    fortran.c
     xcfun.cpp
     xcint.cpp
+  )
+
+add_library(xcfun-c-objlib OBJECT fortran.c)
+set_target_properties(xcfun-c-objlib
+  PROPERTIES
+    POSITION_INDEPENDENT_CODE 1
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN 1
+  )
+target_compile_options(xcfun-c-objlib
+  # FIXME These should be PUBLIC, but then Fortran inherits flags it doesn't
+  # understand...
+  PRIVATE
+    "${XCFun_C_FLAGS}"
+    "$<$<BOOL:${OPENMP_FOUND}>:${OpenMP_C_FLAGS}>"
+  PRIVATE
+    "$<$<CONFIG:Debug>:${XCFun_C_FLAGS_DEBUG}>"
+    "$<$<CONFIG:Release>:${XCFun_C_FLAGS_RELEASE}>"
+    "$<$<BOOL:${ENABLE_CODE_COVERAGE}>:${XCFun_C_FLAGS_COVERAGE}>"
+  )
+target_compile_definitions(xcfun-c-objlib
   PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/config.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/densvars.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/functional.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/specmath.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/xcint.hpp
+    XCFun_EXPORTS
+    "$<$<BOOL:${ENABLE_64BIT_INTEGERS}>:XCFun_FORTRAN_INT=long long int>"
+  )
+target_include_directories(xcfun-c-objlib
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/api
+    ${PROJECT_BINARY_DIR}/include
   )
 
 add_subdirectory(functionals)
 
 if(NOT STATIC_LIBRARY_ONLY)
-  add_library(xcfun-shared SHARED $<TARGET_OBJECTS:xcfun-objlib>)
+  add_library(xcfun-shared SHARED
+    $<TARGET_OBJECTS:xcfun-objlib>
+    $<TARGET_OBJECTS:xcfun-c-objlib>
+    )
   target_compile_definitions(xcfun-shared
     PUBLIC
       XCFun_EXPORTS
@@ -73,8 +96,6 @@ if(NOT STATIC_LIBRARY_ONLY)
     PROPERTIES
       VERSION ${PROJECT_VERSION_MAJOR}
       SOVERSION ${PROJECT_VERSION_MAJOR}
-      CXX_VISIBILITY_PRESET hidden
-      VISIBILITY_INLINES_HIDDEN 1
       MACOSX_RPATH ON
       OUTPUT_NAME "xcfun"
       EXPORT_NAME "xcfun"
@@ -92,7 +113,10 @@ if(NOT STATIC_LIBRARY_ONLY)
 endif()
 
 if(NOT SHARED_LIBRARY_ONLY)
-  add_library(xcfun-static STATIC $<TARGET_OBJECTS:xcfun-objlib>)
+  add_library(xcfun-static STATIC
+    $<TARGET_OBJECTS:xcfun-objlib>
+    $<TARGET_OBJECTS:xcfun-c-objlib>
+    )
   target_compile_definitions(xcfun-static
     PUBLIC
       XCFun_STATIC_DEFINE
@@ -101,7 +125,7 @@ if(NOT SHARED_LIBRARY_ONLY)
     )
   target_include_directories(xcfun-static
     INTERFACE
-      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/api>
       $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )


### PR DESCRIPTION
## Description
We now check for the available C++11/C99 standards compiler flags instead of relying on CMake.
CMake 3.5 is not aware of these flags for some commercial compilers, leading to compilation failures, see #69 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go