### PR TITLE
Manual rebase of the user friendly setup routine

### DIFF
--- a/api/xcfun.h
+++ b/api/xcfun.h
@@ -49,48 +49,45 @@ enum xc_mode {
 };
 
 // Must be in sync with xcint_vars in xcint.cpp and with the fortran module
+/*! \enum xc_vars
+ *  \brief functional type
+ */
 enum xc_vars {
-  XC_VARS_UNSET = -1,
-  // LDA
-  XC_A,
-  XC_N,
-  XC_A_B,
-  XC_N_S,
-  // GGA with gradient squares
-  XC_A_GAA,
-  XC_N_GNN,
-  XC_A_B_GAA_GAB_GBB,
-  XC_N_S_GNN_GNS_GSS,
-  // Meta-GGA
-  XC_A_GAA_LAPA,
-  XC_A_GAA_TAUA,
-  XC_N_GNN_LAPN, // 10
-  XC_N_GNN_TAUN,
-  XC_A_B_GAA_GAB_GBB_LAPA_LAPB,
-  XC_A_B_GAA_GAB_GBB_TAUA_TAUB,
-  XC_N_S_GNN_GNS_GSS_LAPN_LAPS,
-  XC_N_S_GNN_GNS_GSS_TAUN_TAUS,
-  XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB,
-  XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB_JPAA_JPBB,
-  XC_N_S_GNN_GNS_GSS_LAPN_LAPS_TAUN_TAUS,
-  // GGA with individual gradient components
-  XC_A_AX_AY_AZ,
-  XC_A_B_AX_AY_AZ_BX_BY_BZ,
-  XC_N_NX_NY_NZ, // 20
-  XC_N_S_NX_NY_NZ_SX_SY_SZ,
-  // Meta-GGA with individual gradient components
-  XC_A_AX_AY_AZ_TAUA,
-  XC_A_B_AX_AY_AZ_BX_BY_BZ_TAUA_TAUB,
-  XC_N_NX_NY_NZ_TAUN,
-  XC_N_S_NX_NY_NZ_SX_SY_SZ_TAUN_TAUS,
-  /* 2:nd order Taylor coefficients of alpha density, 1+3+6=10
-     numbers, rev gradlex order */
-  XC_A_2ND_TAYLOR,
-  /* 2:nd order Taylor expansion of alpha and beta densities
-     (first alpha, then beta) 20 numbers */
-  XC_A_B_2ND_TAYLOR,
-  XC_N_2ND_TAYLOR,
-  XC_N_S_2ND_TAYLOR,
+  XC_VARS_UNSET = -1, /*!< Not defined */
+  XC_A,               /*! LDA alpha */
+  XC_N,               /*! LDA rho*/
+  XC_A_B,             /*! LDA alpha & beta */
+  XC_N_S,             /*! LDA rho and spin */
+
+  XC_A_GAA,             /*! GGA with grad^2 alpha        */       
+  XC_N_GNN,             /*! GGA with grad^2 rho          */          
+  XC_A_B_GAA_GAB_GBB,   /*! GGA with grad^2 alpha & beta */
+  XC_N_S_GNN_GNS_GSS,   /*! GGA with grad^2 rho and spin */
+  XC_A_GAA_LAPA,                                    /*! metaGGA with grad^2 alpha        laplacian */        
+  XC_A_GAA_TAUA,                                    /*! metaGGA with grad^2 alpha        kinetic   */       
+  XC_N_GNN_LAPN,                                    /*! metaGGA with grad^2 rho          laplacian */ // 10
+  XC_N_GNN_TAUN,                                    /*! metaGGA with grad^2 rho          kinetic   */          
+  XC_A_B_GAA_GAB_GBB_LAPA_LAPB,                     /*! metaGGA with grad^2 alpha & beta laplacian */
+  XC_A_B_GAA_GAB_GBB_TAUA_TAUB,                     /*! metaGGA with grad^2 alpha & beta kinetic   */
+  XC_N_S_GNN_GNS_GSS_LAPN_LAPS,                     /*! metaGGA with grad^2 rho and spin laplacian */
+  XC_N_S_GNN_GNS_GSS_TAUN_TAUS,                     /*! metaGGA with grad^2 rho and spin kinetic   */
+  XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB,           /*! metaGGA with grad^2 alpha & beta laplacian kinetic */
+  XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB_JPAA_JPBB, /*! metaGGA with grad^2 alpha & beta laplacian kinetic current */
+  XC_N_S_GNN_GNS_GSS_LAPN_LAPS_TAUN_TAUS,           /*! metaGGA with grad^2 rho and spin laplacian kinetic */
+  XC_A_AX_AY_AZ,             /*! GGA with gradient components alpha        */           
+  XC_A_B_AX_AY_AZ_BX_BY_BZ,  /*! GGA with gradient components alpha & beta */
+  XC_N_NX_NY_NZ,             /*! GGA with gradient components rho          */ // 20
+  XC_N_S_NX_NY_NZ_SX_SY_SZ,  /*! GGA with gradient components rho and spin */
+  XC_A_AX_AY_AZ_TAUA,                 /*! metaGGA with gradient components alpha        */
+  XC_A_B_AX_AY_AZ_BX_BY_BZ_TAUA_TAUB, /*! metaGGA with gradient components alpha & beta */
+  XC_N_NX_NY_NZ_TAUN,                 /*! metaGGA with gradient components rho          */
+  XC_N_S_NX_NY_NZ_SX_SY_SZ_TAUN_TAUS, /*! metaGGA with gradient components rho and spin */
+  /* 2:nd order Taylor coefficients of alpha density, 1+3+6=10 numbers, rev gradlex order */
+  XC_A_2ND_TAYLOR,    /*! 2:nd order Taylor alpha        */ 
+  /* 2:nd order Taylor expansion of alpha and beta densities (first alpha, then beta) 20 numbers */
+  XC_A_B_2ND_TAYLOR,  /*! 2:nd order Taylor alpha & beta */
+  XC_N_2ND_TAYLOR,    /*! 2:nd order Taylor rho          */
+  XC_N_S_2ND_TAYLOR,  /*! 2:nd order Taylor rho and spin */
   XC_NR_VARS
 };
 

--- a/api/xcfun.h
+++ b/api/xcfun.h
@@ -128,7 +128,7 @@ const char * xc_describe_long(const char * name);
 XCFun_API int xc_is_gga(xc_functional fun);
 XCFun_API int xc_is_metagga(xc_functional fun);
 
-int xc_set_fromstring(xc_functional fun, const char * str); // Defines a functional
+XCFun_API int xc_set_fromstring(xc_functional fun, const char * str); // Defines a functional
                                                             // from a string on the
                                                             // form "fun[=value]"
 

--- a/api/xcfun.h
+++ b/api/xcfun.h
@@ -132,6 +132,16 @@ int xc_set_fromstring(xc_functional fun, const char * str); // Defines a functio
                                                             // from a string on the
                                                             // form "fun[=value]"
 
+int xc_user_eval_setup(xc_functional fun,
+                       const int order, // order of the derivative requested (order=1 is the xc potential)
+                       const unsigned int func_type, // LDA (0), GGA (1), metaGGA (2), taylor (3)
+                       const unsigned int dens_type,  // A (0), N (1), A_B (2), N_S (3)
+                       const unsigned int mode_type,  // same as the enum list
+                       const unsigned int laplacian,  // 0/1 laplacian no/yes 
+                       const unsigned int kinetic,    // 0/1 kinetic energy no/yes
+                       const unsigned int current,    // 0/1 current density no/yes
+                       const unsigned int explicit_derivatives);   // 0/1 gamma vs explicit partial derivatives 
+
 // Try to set the functional evaluation vars, mode and order
 // return some combination of XC_E* if an error occurs, else 0.
 XCFun_API int xc_eval_setup(xc_functional fun,

--- a/api/xcfun.h
+++ b/api/xcfun.h
@@ -132,7 +132,7 @@ XCFun_API int xc_set_fromstring(xc_functional fun, const char * str); // Defines
                                                             // from a string on the
                                                             // form "fun[=value]"
 
-int xc_user_eval_setup(xc_functional fun,
+XCFun_API int xc_user_eval_setup(xc_functional fun,
                        const int order, // order of the derivative requested (order=1 is the xc potential)
                        const unsigned int func_type, // LDA (0), GGA (1), metaGGA (2), taylor (3)
                        const unsigned int dens_type,  // A (0), N (1), A_B (2), N_S (3)

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -730,9 +730,9 @@ int xc_is_metagga(xc_functional fun) {
   return (fun->depends & (XC_LAPLACIAN | XC_KINETIC));
 }
 
-/*! brief host program-friendly setup of the functional
+/*! @brief host program-friendly setup of the functional
  *
- * param[in] fun the functional object
+ * param[in,out] fun the functional object
  * param[in] order 0 (functional), 1 (potential), 2 (hessian), ....
  * param[in] func_type LDA (0), GGA (1), metaGGA (2), taylor (3)
  * param[in] dens_type Alpha (A,0), Rho (N,1), Alpha&Beta (A_B,2), Rho&Spin (N_S,3)

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -729,3 +729,102 @@ int xc_is_gga(xc_functional fun) { return (fun->depends & XC_GRADIENT); }
 int xc_is_metagga(xc_functional fun) {
   return (fun->depends & (XC_LAPLACIAN | XC_KINETIC));
 }
+
+int xc_user_eval_setup(xc_functional fun,
+                       const int order,
+                       const unsigned int func_type, // LDA (0), GGA (1), metaGGA (2), taylor (3)
+                       const unsigned int dens_type,  // A (0), N (1), A_B (2), N_S (3)
+                       const unsigned int mode_type,  // same as the enum list
+                       const unsigned int laplacian,  // 0/1 laplacian no/yes 
+                       const unsigned int kinetic,    // 0/1 kinetic energy no/yes
+                       const unsigned int current,    // 0/1 current density no/yes
+                       const unsigned int explicit_derivatives) {   // 0/1 gamma vs explicit partial derivatives 
+
+    if (func_type > 3 || dens_type > 3 || mode_type > 3 || laplacian > 1 || kinetic > 1 || current > 1 || explicit_derivatives > 1) {
+        xcint_die("xc_user_eval_setup: invalid input",-1);
+    }
+    
+
+    enum xc_vars vars = XC_VARS_UNSET; 
+    enum xc_mode mode = XC_MODE_UNSET;
+    
+    switch (mode_type){
+    case(1): mode = XC_PARTIAL_DERIVATIVES; break;
+    case(2): mode = XC_POTENTIAL;           break;
+    case(3): mode = XC_CONTRACTED;          break;
+    default:
+        xcint_die("xc_user_eval_setup: Invalid mode", mode_type);
+    }
+
+
+    /* Bit encoding of information 
+       7   6   5   4   3   2   1   0
+    ------------------------------------------------------------------
+       0   0                             LDA
+       0   1                             GGA
+       1   0                             metaGGA
+       1   1                             Taylor
+    ------------------------------------------------------------------
+               0   0                     alpha density
+               0   1                     n density
+               1   0                     anpha and beta densities
+               1   1                     n and s density
+    ------------------------------------------------------------------
+                       0                 no laplacian 
+                       1                 laplacian required
+    ------------------------------------------------------------------
+                           0             no kinetic energy
+                           1             kinetic energy required
+    ------------------------------------------------------------------
+                               0         no current density required
+                               1         current density required
+    ------------------------------------------------------------------
+                                   0     gamma-type partial derivatives
+                                   1     explicit partial derivatives
+     */
+
+    int bitwise_vars = 0;
+    bitwise_vars += func_type << 6;       // 0 64 128 192
+    bitwise_vars += dens_type << 4;       // 0 16  32  48
+    bitwise_vars += laplacian << 3;       // 0  8
+    bitwise_vars += kinetic   << 2;       // 0  4
+    bitwise_vars += current   << 1;       // 0  2
+    bitwise_vars += explicit_derivatives; // 0  1
+
+    switch(bitwise_vars){
+    case(0):    vars = XC_A;                                             break;  // 0  0  |  0  0  |  0  |  0  |  0  |  0
+    case(16):   vars = XC_N;                                             break;  // 0  0  |  0  1  |  0  |  0  |  0  |  0
+    case(32):   vars = XC_A_B;                                           break;  // 0  0  |  1  0  |  0  |  0  |  0  |  0
+    case(48):   vars = XC_N_S;                                           break;  // 0  0  |  1  1  |  0  |  0  |  0  |  0
+    case(64):   vars = XC_A_GAA;                                         break;  // 0  1  |  0  0  |  0  |  0  |  0  |  0
+    case(65):   vars = XC_A_AX_AY_AZ;                                    break;  // 0  1  |  0  0  |  0  |  0  |  0  |  1
+    case(80):   vars = XC_N_GNN;                                         break;  // 0  1  |  0  1  |  0  |  0  |  0  |  0
+    case(81):   vars = XC_N_NX_NY_NZ;                                    break;  // 0  1  |  0  1  |  0  |  0  |  0  |  1
+    case(96):   vars = XC_A_B_GAA_GAB_GBB;                               break;  // 0  1  |  1  0  |  0  |  0  |  0  |  0
+    case(97):   vars = XC_A_B_AX_AY_AZ_BX_BY_BZ;                         break;  // 0  1  |  1  0  |  0  |  0  |  0  |  1
+    case(112):  vars = XC_N_S_GNN_GNS_GSS;                               break;  // 0  1  |  1  1  |  0  |  0  |  0  |  0
+    case(113):  vars = XC_N_S_NX_NY_NZ_SX_SY_SZ;                         break;  // 0  1  |  1  1  |  0  |  0  |  0  |  1
+    case(132):  vars = XC_A_GAA_TAUA;                                    break;  // 1  0  |  0  0  |  0  |  1  |  0  |  0
+    case(133):  vars = XC_A_AX_AY_AZ_TAUA;                               break;  // 1  0  |  0  0  |  0  |  1  |  0  |  1
+    case(136):  vars = XC_A_GAA_LAPA;                                    break;  // 1  0  |  0  0  |  1  |  0  |  0  |  0
+    case(148):  vars = XC_N_GNN_TAUN;                                    break;  // 1  0  |  0  1  |  0  |  1  |  0  |  0
+    case(149):  vars = XC_N_NX_NY_NZ_TAUN;                               break;  // 1  0  |  0  1  |  0  |  1  |  0  |  1
+    case(152):  vars = XC_N_GNN_LAPN;                                    break;  // 1  0  |  0  1  |  1  |  0  |  0  |  0
+    case(164):  vars = XC_A_B_GAA_GAB_GBB_TAUA_TAUB;                     break;  // 1  0  |  1  0  |  0  |  1  |  0  |  0
+    case(165):  vars = XC_A_B_AX_AY_AZ_BX_BY_BZ_TAUA_TAUB;               break;  // 1  0  |  1  0  |  0  |  1  |  0  |  1
+    case(168):  vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB;                     break;  // 1  0  |  1  0  |  1  |  0  |  0  |  0
+    case(172):  vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB;           break;  // 1  0  |  1  0  |  1  |  1  |  0  |  0
+    case(174):  vars = XC_A_B_GAA_GAB_GBB_LAPA_LAPB_TAUA_TAUB_JPAA_JPBB; break;  // 1  0  |  1  0  |  1  |  1  |  1  |  0
+    case(180):  vars = XC_N_S_GNN_GNS_GSS_TAUN_TAUS;                     break;  // 1  0  |  1  1  |  0  |  1  |  0  |  0
+    case(181):  vars = XC_N_S_NX_NY_NZ_SX_SY_SZ_TAUN_TAUS;               break;  // 1  0  |  1  1  |  0  |  1  |  0  |  1
+    case(184):  vars = XC_N_S_GNN_GNS_GSS_LAPN_LAPS;                     break;  // 1  0  |  1  1  |  1  |  0  |  0  |  0
+    case(188):  vars = XC_N_S_GNN_GNS_GSS_LAPN_LAPS_TAUN_TAUS;           break;  // 1  0  |  1  1  |  1  |  1  |  0  |  0
+    case(192):  vars = XC_A_2ND_TAYLOR;                                  break;  // 1  1  |  0  0  |  0  |  0  |  0  |  0
+    case(208):  vars = XC_N_2ND_TAYLOR;                                  break;  // 1  1  |  0  1  |  0  |  0  |  0  |  0
+    case(224):  vars = XC_A_B_2ND_TAYLOR;                                break;  // 1  1  |  1  0  |  0  |  0  |  0  |  0
+    case(240):  vars = XC_N_S_2ND_TAYLOR;                                break;  // 1  1  |  1  1  |  0  |  0  |  0  |  0
+    default:
+        xcint_die("xc_user_eval_setup: Invalid vars", bitwise_vars);
+    }
+    return xc_eval_setup(fun, vars, mode, order);
+}

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -731,8 +731,8 @@ int xc_is_metagga(xc_functional fun) {
 }
 
 /*! brief host program-friendly setup of the functional
- * 
- * param[in] fun the functional object 
+ *
+ * param[in] fun the functional object
  * param[in] func_type LDA (0), GGA (1), metaGGA (2), taylor (3)
  * param[in] dens_type Alpha (A,0), Rho (N,1), Alpha&Beta (A_B,2), Rho&Spin (N_S,3)
  * param[in] mode_type Parital derivatives (1), Potential (2), Contracted (3)
@@ -748,22 +748,23 @@ int xc_is_metagga(xc_functional fun) {
 
 int xc_user_eval_setup(xc_functional fun,
                        const int order,
-                       const unsigned int func_type,  
-                       const unsigned int dens_type,  
-                       const unsigned int mode_type,  
-                       const unsigned int laplacian,  
-                       const unsigned int kinetic,    
-                       const unsigned int current,    
-                       const unsigned int explicit_derivatives) {   
+                       const unsigned int func_type,
+                       const unsigned int dens_type,
+                       const unsigned int mode_type,
+                       const unsigned int laplacian,
+                       const unsigned int kinetic,
+                       const unsigned int current,
+                       const unsigned int explicit_derivatives) {
 
-    if (func_type > 3 || dens_type > 3 || mode_type > 3 || laplacian > 1 || kinetic > 1 || current > 1 || explicit_derivatives > 1) {
-        xcint_die("xc_user_eval_setup: invalid input",-1);
-    }
-    
-    
-    enum xc_vars vars = XC_VARS_UNSET; 
-    enum xc_mode mode = XC_MODE_UNSET;
-    
+  if (func_type > 3 || dens_type > 3 || mode_type > 3 || laplacian > 1 ||
+      kinetic > 1 || current > 1 || explicit_derivatives > 1) {
+    xcint_die("xc_user_eval_setup: invalid input", -1);
+  }
+
+  enum xc_vars vars = XC_VARS_UNSET;
+  enum xc_mode mode = XC_MODE_UNSET;
+
+  // clang-format off
     switch (mode_type){
     case(1): mode = XC_PARTIAL_DERIVATIVES; break;
     case(2): mode = XC_POTENTIAL;           break;
@@ -843,5 +844,5 @@ int xc_user_eval_setup(xc_functional fun,
         xcint_die("xc_user_eval_setup: Invalid vars", bitwise_vars);
     }
     return xc_eval_setup(fun, vars, mode, order);
-    // clang-format on
+  // clang-format on
 }

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -730,21 +730,37 @@ int xc_is_metagga(xc_functional fun) {
   return (fun->depends & (XC_LAPLACIAN | XC_KINETIC));
 }
 
+/*! brief host program-friendly setup of the functional
+ * 
+ * param[in] fun the functional object 
+ * param[in] func_type LDA (0), GGA (1), metaGGA (2), taylor (3)
+ * param[in] dens_type Alpha (A,0), Rho (N,1), Alpha&Beta (A_B,2), Rho&Spin (N_S,3)
+ * param[in] mode_type Parital derivatives (1), Potential (2), Contracted (3)
+ * param[in] laplacian (0 not required / 1 required)
+ * param[in] kinentic  (0 not required / 1 required)
+ * param[in] current   (0 not required / 1 required)
+ * param[in] explict_derivatives  (0 not required / 1 required)
+ *
+ * This routine encodes the different options bitwise. Each legitimate
+ * combination is then converted to the corresponding enum value.
+ *
+ */
+
 int xc_user_eval_setup(xc_functional fun,
                        const int order,
-                       const unsigned int func_type, // LDA (0), GGA (1), metaGGA (2), taylor (3)
-                       const unsigned int dens_type,  // A (0), N (1), A_B (2), N_S (3)
-                       const unsigned int mode_type,  // same as the enum list
-                       const unsigned int laplacian,  // 0/1 laplacian no/yes 
-                       const unsigned int kinetic,    // 0/1 kinetic energy no/yes
-                       const unsigned int current,    // 0/1 current density no/yes
-                       const unsigned int explicit_derivatives) {   // 0/1 gamma vs explicit partial derivatives 
+                       const unsigned int func_type,  
+                       const unsigned int dens_type,  
+                       const unsigned int mode_type,  
+                       const unsigned int laplacian,  
+                       const unsigned int kinetic,    
+                       const unsigned int current,    
+                       const unsigned int explicit_derivatives) {   
 
     if (func_type > 3 || dens_type > 3 || mode_type > 3 || laplacian > 1 || kinetic > 1 || current > 1 || explicit_derivatives > 1) {
         xcint_die("xc_user_eval_setup: invalid input",-1);
     }
     
-
+    
     enum xc_vars vars = XC_VARS_UNSET; 
     enum xc_mode mode = XC_MODE_UNSET;
     
@@ -827,4 +843,5 @@ int xc_user_eval_setup(xc_functional fun,
         xcint_die("xc_user_eval_setup: Invalid vars", bitwise_vars);
     }
     return xc_eval_setup(fun, vars, mode, order);
+    // clang-format on
 }

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -733,6 +733,7 @@ int xc_is_metagga(xc_functional fun) {
 /*! brief host program-friendly setup of the functional
  *
  * param[in] fun the functional object
+ * param[in] order 0 (functional), 1 (potential), 2 (hessian), ....
  * param[in] func_type LDA (0), GGA (1), metaGGA (2), taylor (3)
  * param[in] dens_type Alpha (A,0), Rho (N,1), Alpha&Beta (A_B,2), Rho&Spin (N_S,3)
  * param[in] mode_type Parital derivatives (1), Potential (2), Contracted (3)

--- a/test/testall.c
+++ b/test/testall.c
@@ -126,11 +126,20 @@ void gradient_forms_test(void) {
   xc_free_functional(fun);
 }
 
+void user_setup_test() {
+    xc_functional fun = xc_new_functional();
+    xc_set(fun, "pbe", 1.0);
+    int rval = xc_user_eval_setup(fun, 1, 1, 2, 1, 0, 0, 0, 1);
+    check("Functional correctly set up",  rval == 0);
+    xc_free_functional(fun);
+}
+
 int main(void) {
   int i = 0;
   const char *n, *s;
   consistency_test();
   gradient_forms_test();
+  user_setup_test();
   printf("%s", xcfun_splash());
   printf("XCFun version: %g\n", xcfun_version());
   printf("\nAvailable functionals and other settings:\n");

--- a/test/testall.c
+++ b/test/testall.c
@@ -127,11 +127,21 @@ void gradient_forms_test(void) {
 }
 
 void user_setup_test() {
-    xc_functional fun = xc_new_functional();
-    xc_set(fun, "pbe", 1.0);
-    int rval = xc_user_eval_setup(fun, 1, 1, 2, 1, 0, 0, 0, 1);
-    check("Functional correctly set up",  rval == 0);
-    xc_free_functional(fun);
+    xc_functional fun1 = xc_new_functional();
+    xc_functional fun2 = xc_new_functional();
+    xc_functional fun3 = xc_new_functional();
+    xc_set(fun1, "lda",  1.0);
+    xc_set(fun2, "pbe",  1.0);
+    xc_set(fun3, "m06l", 1.0);
+    int rval1 = xc_user_eval_setup(fun1, 0, 0, 0, 1, 0, 0, 0, 0);
+    int rval2 = xc_user_eval_setup(fun2, 1, 1, 1, 1, 0, 0, 0, 1);
+    int rval3 = xc_user_eval_setup(fun3, 2, 2, 2, 1, 0, 1, 0, 1);
+    check("Functional 1 correctly set up", rval1 == 0);
+    check("Functional 2 correctly set up", rval2 == 0);
+    check("Functional 3 correctly set up", rval3 == 0);
+    xc_free_functional(fun1);
+    xc_free_functional(fun2);
+    xc_free_functional(fun3);
 }
 
 int main(void) {


### PR DESCRIPTION
The new routine takes a few integers as input. It combines them with bit manipulations. The final value corresponds to a unique eval xc_vars. Another integer fixes eval xc_mode.
The return statement calls the original xc_eval_setup.

I have not tested it yet. Feedback welcome :-)

Still missing:

- sanity checks for the input integers
- graceful error exit in case the requested combination is not available.
- unit test for the new routine
