### PR TITLE
Change XCFUN_ACCURATE_PBEX_MU -> XCFUN_REF_PBEX_MU

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -24,7 +24,7 @@
 // PW92C. This matches the reference implementation.
 
 // Use inaccurate mu value in pbe exchange.
-// #define XCFUN_ACCURATE_PBEX_MU
+// #define XCFUN_REF_PBEX_MU
 
 // This is the internal scalar type of the library, can be
 // different from the external interface.


### PR DESCRIPTION
It seems the `XCFUN_ACCURATE_PBEX_MU` parameter that can be activated in `src/config.hpp` is never used in the code and should be replaced by `XCFUN_REF_PBEX_MU`. At least the latter triggers the change I'm looking for when comparing with `libxc`.

## How Has This Been Tested?
Helium energy:
- -2.89293549978 (xcfun using default parameters)
- -2.89293486688 (xcfun using `#define XCFUN_REF_PBEX_MU`)
- -2.89293486679 (libxc)

(`#define XCFUN_ACCURATE_PBEX_MU` triggers nothing at all, since it does not appear in the source code)

## Status
- [x]  Ready to go
