### PR TITLE
Little extension in kernel example: The functional is released now.

### DIFF
--- a/test/kernel_example.f90
+++ b/test/kernel_example.f90
@@ -422,6 +422,10 @@ program xc_example
   deallocate (density)
   deallocate (input_array)
   deallocate (output_array) 
+
+  !Release the functional
+  call xc_free_functional(id)
+
   
   write(*,*)'Kernel test has ended properly!'
   


### PR DESCRIPTION
I have added a call to xc_free_fun to the kernel example.

As I consider the kernel_example file as a kind of template for an xcfun call, I think it is important to "show" the functionality in a more prominent way like this and not by only providing it.

The kernel example file is running properly. In my own code, which calls xcfun, I experienced problems with multiple definitions of new functionals which could be solved by releasing the functional after use.