### PR TITLE
Make xc_get() part of the API

### DIFF
--- a/api/xcfun.h
+++ b/api/xcfun.h
@@ -118,7 +118,7 @@ XCFun_API const char * xc_enumerate_aliases(int n);
 // Try to either set or get a parameter. Return 0 if all was well,
 // otherwise the name was invalid.
 XCFun_API int xc_set(xc_functional fun, const char * name, double value);
-int xc_get(xc_functional fun, const char * name, double * value);
+XCFun_API int xc_get(xc_functional fun, const char * name, double * value);
 XCFun_API const char * xc_describe_short(const char * name);
 const char * xc_describe_long(const char * name);
 

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -666,7 +666,16 @@ int xc_set(xc_functional fun, const char * name, double value) {
   return -1;
 }
 
-// Getting aliases is not supported
+/*! @brief get weight of given functional in the current setup
+ *
+ * param[in] fun the functional object
+ * param[in] name functional name to test, aliases not supported
+ * param[out] value weight of functional
+ *
+ * Returns 0 if name is a valid functional, -1 if not.
+ * See list_of_functionals.hpp for valid functional names.
+ */
+
 int xc_get(xc_functional fun, const char * name, double * value) {
   xcint_assure_setup();
   int item;

--- a/test/testall.c
+++ b/test/testall.c
@@ -144,12 +144,36 @@ void user_setup_test() {
     xc_free_functional(fun3);
 }
 
+void xc_get_test() {
+    xc_functional fun = xc_new_functional();
+    xc_set(fun, "B3LYP", 1.0);
+
+    double s, b, lyp, vwn, exx, kt, foo;
+    check("SLATERX is a valid functional"   , xc_get(fun, "SLATERX", &s) == 0);
+    check("BECKECORRX is a valid functional", xc_get(fun, "BECKECORRX", &b) == 0);
+    check("LYPC is a valid functional"      , xc_get(fun, "LYPC", &lyp) == 0);
+    check("VWN5C is a valid functional"     , xc_get(fun, "VWN5C", &vwn) == 0);
+    check("EXX is a valid functional"       , xc_get(fun, "EXX", &exx) == 0);
+    check("KTX is a valid functional"       , xc_get(fun, "KTX", &kt) == 0);
+    check("FOO is NOT a valid functional"   , xc_get(fun, "FOO", &foo) != 0);
+
+    checknum("B3LYP contains 80% SLATERX"   , s  , 0.80, 1.0e-14, 1.0e-12);
+    checknum("B3LYP contains 72% BECKECORRX", b  , 0.72, 1.0e-14, 1.0e-12);
+    checknum("B3LYP contains 81% LYPC"      , lyp, 0.81, 1.0e-14, 1.0e-12);
+    checknum("B3LYP contains 19% VWN5C"     , vwn, 0.19, 1.0e-14, 1.0e-12);
+    checknum("B3LYP contains 20% EXX"       , exx, 0.20, 1.0e-14, 1.0e-12);
+    checknum("B3LYP contains  0% KTX"       , kt , 0.00, 1.0e-14, 1.0);
+
+    xc_free_functional(fun);
+}
+
 int main(void) {
   int i = 0;
   const char *n, *s;
   consistency_test();
   gradient_forms_test();
   user_setup_test();
+  xc_get_test();
   printf("%s", xcfun_splash());
   printf("XCFun version: %g\n", xcfun_version());
   printf("\nAvailable functionals and other settings:\n");


### PR DESCRIPTION
## Questions
Is there any reason why this function is not part of the C++ API?
```
int xc_get(xc_functional fun, const char * name, double * value);
``` 

## Motivation and Context
I would like to be able to retrieve the amount of exact exchange from XCFun. To me the only reason to keep the `exx` parameter in XCFun is to keep track of it for the host program, but currently I don't see any way to fetch this information (correct me if I'm wrong). I would like to avoid duplication of this parameter.

## Alternative solution
Add specific function to fetch `exx`:
```
XCFun_API double xc_get_exx(xc_functional fun)
```

## Description
Added `XCFun_API` to the `xc_get()` function in xcfun.h.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go
