### PR TITLE
Remove faulty clang compiler flags

### DIFF
--- a/cmake/custom/compilers/CFlags.cmake
+++ b/cmake/custom/compilers/CFlags.cmake
@@ -46,8 +46,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
   list(APPEND XCFun_C_FLAGS
     "${c99_flag}"
     "-m64"
-    "-Qunused-arguments"
-    "-fcolor-diagnostics"
     )
   list(APPEND XCFun_C_FLAGS_DEBUG
     "-Wall"

--- a/cmake/custom/compilers/CXXFlags.cmake
+++ b/cmake/custom/compilers/CXXFlags.cmake
@@ -52,8 +52,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
     "-fno-rtti"
     "-fno-exceptions"
     "-m64"
-    "-Qunused-arguments"
-    "-fcolor-diagnostics"
     )
   list(APPEND XCFun_CXX_FLAGS_DEBUG
     "-Wall"


### PR DESCRIPTION
The following compiler flags are not valid for Clang:
```
-Qunused-arguments
-fcolor-diagnostics
```