### PR TITLE
Add alias for cleaner use with FetchContent

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -146,10 +146,13 @@ if(NOT SHARED_LIBRARY_ONLY)
     )
 endif()
 
+# The second alias is useful with FetchContent
 if(STATIC_LIBRARY_ONLY)
   add_library(XCFun ALIAS xcfun-static)
+  add_library(XCFun::xcfun ALIAS xcfun-static)
 else()
   add_library(XCFun ALIAS xcfun-shared)
+  add_library(XCFun::xcfun ALIAS xcfun-shared)
 endif()
 
 include(GenerateExportHeader)


### PR DESCRIPTION
Provides an alias to the library so that use with `FetchContent` or imported target looks the same:
`target_link_libraries(foo PRIVATE XCFun::xcfun)`

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go
