### PR TITLE
Drop Python 2.7 from CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: cpp
 sudo: false
-dist: xenial
+dist: bionic 
 
 matrix:
   include:
-    # 1/ Linux Clang Builds
+    # 1/ Linux recent Clang Builds
     - os: linux
       compiler: clang
-      addons: &clang34
+      addons:
         apt:
           packages:
             - clang
@@ -22,101 +22,35 @@ matrix:
         - PYBIND11='-Dpybind11_DIR=$HOME/Deps/pybind11/share/cmake/pybind11'
     - os: linux
       compiler: clang
-      addons: &clang35
+      addons: 
         apt:
           packages:
-            - clang-3.5
+            - clang
             - gfortran
       env:
-        - CXX_COMPILER='clang++-3.5'
-        - C_COMPILER='clang-3.5'
-        - Fortran_COMPILER='gfortran'
-        - BUILD_TYPE='Release'
-        - PYTHON='--two'
-        - COVERAGE=OFF
-    - os: linux
-      compiler: clang
-      addons: &clang38
-        apt:
-          packages:
-            - clang-3.8
-            - gfortran
-      env:
-        - CXX_COMPILER='clang++-3.8'
-        - C_COMPILER='clang-3.8'
+        - CXX_COMPILER='clang++'
+        - C_COMPILER='clang'
         - Fortran_COMPILER='gfortran'
         - BUILD_TYPE='Release'
         - PYTHON='--three'
         - COVERAGE=OFF
-    # 2/ Linux GCC Builds
+    # 2/ Linux recent GCC Builds
     - os: linux
       compiler: gcc
-      addons: &gcc48
+      addons:
         apt:
           packages:
-            - g++-4.8
-            - gcc-4.8
-            - gfortran-4.8
+            - g++
+            - gcc
+            - gfortran
       env:
-        - CXX_COMPILER='g++-4.8'
-        - C_COMPILER='gcc-4.8'
-        - Fortran_COMPILER='gfortran-4.8'
+        - CXX_COMPILER='g++'
+        - C_COMPILER='gcc'
+        - Fortran_COMPILER='gfortran'
         - BUILD_TYPE='Release'
-        - PYTHON='--two'
+        - PYTHON='--three'
         - COVERAGE=OFF
         - PYBIND11='-Dpybind11_DIR=$HOME/Deps/pybind11/share/cmake/pybind11'
-    - os: linux
-      python: 3.6
-      compiler: gcc
-      addons: &gcc5
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-            - gcc-5
-            - gfortran-5
-      env:
-        - CXX_COMPILER='g++-5'
-        - C_COMPILER='gcc-5'
-        - Fortran_COMPILER='gfortran-5'
-        - BUILD_TYPE='Release'
-        - PYTHON='--three'
-        - COVERAGE=OFF
-    - os: linux
-      compiler: gcc
-      addons: &gcc6
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-            - gcc-6
-            - gfortran-6
-      env:
-        - CXX_COMPILER='g++-6'
-        - C_COMPILER='gcc-6'
-        - Fortran_COMPILER='gfortran-6'
-        - BUILD_TYPE='Release'
-        - PYTHON='--two'
-        - COVERAGE=OFF
-    - os: linux
-      compiler: gcc
-      addons: &gcc7
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-            - gcc-7
-            - gfortran-7
-      env:
-        - CXX_COMPILER='g++-7'
-        - C_COMPILER='gcc-7'
-        - Fortran_COMPILER='gfortran-7'
-        - BUILD_TYPE='Release'
-        - PYTHON='--three'
-        - COVERAGE=OFF
     # 3/ OSX Clang Builds
     - os: osx
       compiler: clang
@@ -132,7 +66,7 @@ matrix:
         - C_COMPILER='clang'
         - Fortran_COMPILER='gfortran'
         - BUILD_TYPE='Release'
-        - PYTHON='--two'
+        - PYTHON='--three'
         - COVERAGE=OFF
         - PYBIND11='-Dpybind11_DIR=$HOME/Deps/pybind11/share/cmake/pybind11'
     # 4/ OSX GCC Builds
@@ -153,22 +87,20 @@ matrix:
         - BUILD_TYPE='Release'
         - PYTHON='--three'
         - COVERAGE=OFF
-    # 5/ Linux GCC7 Coverage build
+    # 5/ Linux GCC Coverage build
     - os: linux
       compiler: gcc
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
           packages:
-            - g++-7
-            - gcc-7
-            - gfortran-7
+            - g++
+            - gcc
+            - gfortran
             - lcov
       env:
-        - CXX_COMPILER='g++-7'
-        - C_COMPILER='gcc-7'
-        - Fortran_COMPILER='gfortran-7'
+        - CXX_COMPILER='g++'
+        - C_COMPILER='gcc'
+        - Fortran_COMPILER='gfortran'
         - BUILD_TYPE='Debug'
         - PYTHON='--three'
         - COVERAGE=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: bionic
 
 matrix:
   include:
-    # 1/ Linux recent Clang Builds
+    # Linux recent Clang Builds
     - os: linux
       compiler: clang
       python: 3.6
@@ -34,7 +34,7 @@ matrix:
         - Fortran_COMPILER='gfortran'
         - BUILD_TYPE='Release'
         - COVERAGE=OFF
-    # 2/ Linux recent GCC Builds
+    # Linux recent GCC Builds
     - os: linux
       compiler: gcc
       python: 3.6
@@ -51,7 +51,7 @@ matrix:
         - BUILD_TYPE='Release'
         - COVERAGE=OFF
         - PYBIND11='-Dpybind11_DIR=$HOME/Deps/pybind11/share/cmake/pybind11'
-    # 3/ OSX Clang Builds
+    # OSX Clang Builds
     - os: osx
       osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
       compiler: clang
@@ -69,25 +69,7 @@ matrix:
         - BUILD_TYPE='Release'
         - COVERAGE=OFF
         - PYBIND11='-Dpybind11_DIR=$HOME/Deps/pybind11/share/cmake/pybind11'
-    # 4/ OSX GCC Builds
-    - os: osx
-      osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
-      compiler: gcc
-      language: shell       # 'language: python' is an error on Travis CI macOS
-      addons:
-        homebrew:
-          packages:
-            - gcc
-            - cmake
-            - pipenv
-          update: true
-      env:
-        - CXX_COMPILER='g++'
-        - C_COMPILER='gcc'
-        - Fortran_COMPILER='gfortran'
-        - BUILD_TYPE='Release'
-        - COVERAGE=OFF
-    # 5/ Linux GCC Coverage build
+    # Linux GCC Coverage build
     - os: linux
       python: 3.6
       compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
     # 1/ Linux recent Clang Builds
     - os: linux
       compiler: clang
+      python: 3.6
       addons:
         apt:
           packages:
@@ -17,11 +18,11 @@ matrix:
         - C_COMPILER='clang'
         - Fortran_COMPILER='gfortran'
         - BUILD_TYPE='Release'
-        - PYTHON='--three'
         - COVERAGE=OFF
         - PYBIND11='-Dpybind11_DIR=$HOME/Deps/pybind11/share/cmake/pybind11'
     - os: linux
       compiler: clang
+      python: 3.6
       addons: 
         apt:
           packages:
@@ -32,11 +33,11 @@ matrix:
         - C_COMPILER='clang'
         - Fortran_COMPILER='gfortran'
         - BUILD_TYPE='Release'
-        - PYTHON='--three'
         - COVERAGE=OFF
     # 2/ Linux recent GCC Builds
     - os: linux
       compiler: gcc
+      python: 3.6
       addons:
         apt:
           packages:
@@ -48,17 +49,17 @@ matrix:
         - C_COMPILER='gcc'
         - Fortran_COMPILER='gfortran'
         - BUILD_TYPE='Release'
-        - PYTHON='--three'
         - COVERAGE=OFF
         - PYBIND11='-Dpybind11_DIR=$HOME/Deps/pybind11/share/cmake/pybind11'
     # 3/ OSX Clang Builds
     - os: osx
+      osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
       compiler: clang
+      language: shell       # 'language: python' is an error on Travis CI macOS
       addons:
         homebrew:
           packages:
             - cmake
-            - python
             - pipenv
           update: true
       env:
@@ -66,18 +67,18 @@ matrix:
         - C_COMPILER='clang'
         - Fortran_COMPILER='gfortran'
         - BUILD_TYPE='Release'
-        - PYTHON='--three'
         - COVERAGE=OFF
         - PYBIND11='-Dpybind11_DIR=$HOME/Deps/pybind11/share/cmake/pybind11'
     # 4/ OSX GCC Builds
     - os: osx
+      osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
       compiler: gcc
+      language: shell       # 'language: python' is an error on Travis CI macOS
       addons:
         homebrew:
           packages:
             - gcc
             - cmake
-            - python
             - pipenv
           update: true
       env:
@@ -85,10 +86,10 @@ matrix:
         - C_COMPILER='gcc'
         - Fortran_COMPILER='gfortran'
         - BUILD_TYPE='Release'
-        - PYTHON='--three'
         - COVERAGE=OFF
     # 5/ Linux GCC Coverage build
     - os: linux
+      python: 3.6
       compiler: gcc
       addons:
         apt:
@@ -102,7 +103,6 @@ matrix:
         - C_COMPILER='gcc'
         - Fortran_COMPILER='gfortran'
         - BUILD_TYPE='Debug'
-        - PYTHON='--three'
         - COVERAGE=ON
 
 before_install:
@@ -116,7 +116,7 @@ install:
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
       pip install --user pipenv --upgrade
     fi
-  - pipenv $PYTHON install --dev
+  - pipenv --three install --dev
   - source $(pipenv --venv)/bin/activate
   - ./.ci/cmake.sh
   - ./.ci/pybind11.sh

--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,6 @@ name = "pypi"
 Sphinx = "*"
 fprettify = "*"
 numpy = "*"
-pathlib2 = {version = "*", markers="python_version < '3'"}
 pytest = "*"
 pyyaml = "*"
 sphinx_rtd_theme = "*"

--- a/python/xcfun.py
+++ b/python/xcfun.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # XCFun, an arbitrary order exchange-correlation library
-# Copyright (C) 2019 Ulf Ekström and contributors.
+# Copyright (C) 2020 Ulf Ekström and contributors.
 #
 # This file is part of XCFun.
 #

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/densvars.hpp
+++ b/src/densvars.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functional.hpp
+++ b/src/functional.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/aliases.cpp
+++ b/src/functionals/aliases.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/apbec.cpp
+++ b/src/functionals/apbec.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/apbex.cpp
+++ b/src/functionals/apbex.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/b97-1xc.cpp
+++ b/src/functionals/b97-1xc.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/b97-2xc.cpp
+++ b/src/functionals/b97-2xc.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/b97c.hpp
+++ b/src/functionals/b97c.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/b97x.hpp
+++ b/src/functionals/b97x.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/b97xc.cpp
+++ b/src/functionals/b97xc.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/b97xc.hpp
+++ b/src/functionals/b97xc.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/beckex.cpp
+++ b/src/functionals/beckex.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/blocx.cpp
+++ b/src/functionals/blocx.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/brx.cpp
+++ b/src/functionals/brx.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/btk.cpp
+++ b/src/functionals/btk.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/common_parameters.cpp
+++ b/src/functionals/common_parameters.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/constants.hpp
+++ b/src/functionals/constants.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/cs.cpp
+++ b/src/functionals/cs.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/ktx.cpp
+++ b/src/functionals/ktx.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/lb94.cpp
+++ b/src/functionals/lb94.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/ldaerfc.cpp
+++ b/src/functionals/ldaerfc.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/ldaerfc_jt.cpp
+++ b/src/functionals/ldaerfc_jt.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/ldaerfx.cpp
+++ b/src/functionals/ldaerfx.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/list_of_functionals.hpp
+++ b/src/functionals/list_of_functionals.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/lypc.cpp
+++ b/src/functionals/lypc.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/m05c.cpp
+++ b/src/functionals/m05c.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/m05x.cpp
+++ b/src/functionals/m05x.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/m05x2c.cpp
+++ b/src/functionals/m05x2c.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/m05x2x.cpp
+++ b/src/functionals/m05x2x.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/m06c.cpp
+++ b/src/functionals/m06c.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/m06hfc.cpp
+++ b/src/functionals/m06hfc.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/m06hfx.cpp
+++ b/src/functionals/m06hfx.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/m06lc.cpp
+++ b/src/functionals/m06lc.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/m06lx.cpp
+++ b/src/functionals/m06lx.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/m06x.cpp
+++ b/src/functionals/m06x.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/m06x2c.cpp
+++ b/src/functionals/m06x2c.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/m06x2x.cpp
+++ b/src/functionals/m06x2x.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/m0xy_fun.hpp
+++ b/src/functionals/m0xy_fun.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/optx.cpp
+++ b/src/functionals/optx.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/optxcorr.cpp
+++ b/src/functionals/optxcorr.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/p86c.cpp
+++ b/src/functionals/p86c.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pbec.cpp
+++ b/src/functionals/pbec.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pbec_eps.hpp
+++ b/src/functionals/pbec_eps.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pbeintc.cpp
+++ b/src/functionals/pbeintc.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pbeintx.cpp
+++ b/src/functionals/pbeintx.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pbelocc.cpp
+++ b/src/functionals/pbelocc.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pbesolx.cpp
+++ b/src/functionals/pbesolx.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pbex.cpp
+++ b/src/functionals/pbex.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pbex.hpp
+++ b/src/functionals/pbex.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pw86x.cpp
+++ b/src/functionals/pw86x.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pw91c.cpp
+++ b/src/functionals/pw91c.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pw91k.cpp
+++ b/src/functionals/pw91k.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pw91x.cpp
+++ b/src/functionals/pw91x.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pw92c.cpp
+++ b/src/functionals/pw92c.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pw92eps.hpp
+++ b/src/functionals/pw92eps.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pw9xx.hpp
+++ b/src/functionals/pw9xx.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pz81c.cpp
+++ b/src/functionals/pz81c.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/pz81c.hpp
+++ b/src/functionals/pz81c.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/revpbex.cpp
+++ b/src/functionals/revpbex.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/revtpssc.cpp
+++ b/src/functionals/revtpssc.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/revtpssc_eps.hpp
+++ b/src/functionals/revtpssc_eps.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/revtpssx.cpp
+++ b/src/functionals/revtpssx.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/revtpssx_eps.hpp
+++ b/src/functionals/revtpssx_eps.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/rpbex.cpp
+++ b/src/functionals/rpbex.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/slater.hpp
+++ b/src/functionals/slater.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/slaterx.cpp
+++ b/src/functionals/slaterx.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/spbec.cpp
+++ b/src/functionals/spbec.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/tfk.cpp
+++ b/src/functionals/tfk.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/tpssc.cpp
+++ b/src/functionals/tpssc.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/tpssc_eps.hpp
+++ b/src/functionals/tpssc_eps.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/tpsslocc.cpp
+++ b/src/functionals/tpsslocc.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/tpssx.cpp
+++ b/src/functionals/tpssx.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/tpssx_eps.hpp
+++ b/src/functionals/tpssx_eps.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/tw.cpp
+++ b/src/functionals/tw.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/vonw.cpp
+++ b/src/functionals/vonw.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/vwn.hpp
+++ b/src/functionals/vwn.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/vwn3.cpp
+++ b/src/functionals/vwn3.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/vwn5c.cpp
+++ b/src/functionals/vwn5c.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/zvpbeint.cpp
+++ b/src/functionals/zvpbeint.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/functionals/zvpbesolc.cpp
+++ b/src/functionals/zvpbesolc.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/specmath.hpp
+++ b/src/specmath.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/xcfun.cpp
+++ b/src/xcfun.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/xcint.cpp
+++ b/src/xcint.cpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *

--- a/src/xcint.hpp
+++ b/src/xcint.hpp
@@ -1,6 +1,6 @@
 /*
  * XCFun, an arbitrary order exchange-correlation library
- * Copyright (C) 2019 Ulf Ekström and contributors.
+ * Copyright (C) 2020 Ulf Ekström and contributors.
  *
  * This file is part of XCFun.
  *


### PR DESCRIPTION
I have simplified the CI set up to only run on recent compilers. Older compilers can always be brought back at a later time. Close #103 
Plus update the license year in the source files.

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go
