### PR TITLE
Fix xcfun_get API function

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,11 @@
+version: 2
+
+sphinx:
+  configuration: doc/conf.py
+
+formats:
+  - html
+  - pdf
+
+python:
+  version: 3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The API function `xcfun_get` accepts a single in-out `double` parameter. It
+  was erroneously declared to accept an array of `double`-s instead.
+
+## [Version 2.0.0a3] - 2020-01-31
+
 We have introduced a number of breaking changes, motivated by the need to
 modernize the library. See the [migration guide](docs/migration.rst).
 
@@ -51,7 +58,8 @@ modernize the library. See the [migration guide](docs/migration.rst).
 - **BREAKING** The Fortran interface is no longer build with the code, but
   shipped as a separate file to be compiled within your own Fortran code.
 
-[Unreleased]: https://github.com/dftlibs/xcfun/compare/v2.0.0a2...HEAD
+[Unreleased]: https://github.com/dftlibs/xcfun/compare/v2.0.0a3...HEAD
+[Version 2.0.0a2]: https://github.com/dftlibs/xcfun/compare/v2.0.0a2...v2.0.0a3
 [Version 2.0.0a2]: https://github.com/dftlibs/xcfun/compare/v2.0.0a1...v2.0.0a2
 [Version 2.0.0a1]: https://github.com/dftlibs/xcfun/releases/tag/v2.0.0a1
 

--- a/api/xcfun.f90
+++ b/api/xcfun.f90
@@ -168,7 +168,7 @@ module xcfun
       import
       type(c_ptr), intent(in), value :: fun
       character(kind=c_char, len=1), intent(in) :: name(*)
-      real(c_double), intent(inout) :: val(*)
+      real(c_double), intent(inout) :: val
       integer(c_int) :: err
     end function
 
@@ -347,7 +347,7 @@ contains
   function xcfun_get(fun, param, val) result(err)
     type(c_ptr), value :: fun
     character(kind=c_char, len=*), intent(in) :: param
-    real(c_double), intent(inout) :: val(*)
+    real(c_double), intent(inout) :: val
     integer(c_int) :: err
 
     err = xcfun_get_C(fun, fstring_to_carray(param), val)

--- a/api/xcfun.h
+++ b/api/xcfun.h
@@ -145,7 +145,7 @@ XCFun_API void xcfun_delete(xcfun_t * fun);
 
 XCFun_API int xcfun_set(xcfun_t * fun, const char * name, double value);
 
-XCFun_API int xcfun_get(const xcfun_t * fun, const char * name, double value[]);
+XCFun_API int xcfun_get(const xcfun_t * fun, const char * name, double * value);
 
 XCFun_API bool xcfun_is_gga(const xcfun_t * fun);
 

--- a/examples/Fortran_host/example.f90
+++ b/examples/Fortran_host/example.f90
@@ -26,6 +26,7 @@ program xc_example
                    xcfun_splash, &
                    xcfun_new, &
                    xcfun_set, &
+                   xcfun_get, &
                    xcfun_eval_setup, &
                    xcfun_eval, &
                    xcfun_delete
@@ -46,7 +47,7 @@ program xc_example
 
   integer :: order, ierr, ipoint
   integer :: vector_length
-  real(8) :: res
+  real(8) :: res, weight
 
   real(8), allocatable :: density(:, :, :)
 
@@ -64,6 +65,13 @@ program xc_example
   print *, 'Setting up PBE'
   ierr = xcfun_set(fun, 'pbe', 1.0d0)
   call assert(ierr == 0, "functional name not recognized")
+  ! let's get back the weight of exchange and correlation components
+  ierr = xcfun_get(fun, 'pbex', weight)
+  call assert(ierr == 0, "functional name not recognized")
+  print *, 'PBE exchange weight is ', weight
+  ierr = xcfun_get(fun, 'pbec', weight)
+  call assert(ierr == 0, "functional name not recognized")
+  print *, 'PBE correlation weight is ', weight
 
 
   !-----------------------------------------------------------------------------

--- a/src/XCFunctional.cpp
+++ b/src/XCFunctional.cpp
@@ -406,7 +406,7 @@ int xcfun_set(XCFunctional * fun, const char * name, double value) {
   return -1;
 }
 
-int xcfun_get(const XCFunctional * fun, const char * name, double value[]) {
+int xcfun_get(const XCFunctional * fun, const char * name, double * value) {
   xcint_assure_setup();
   int item;
   if ((item = xcint_lookup_functional(name)) >= 0) {
@@ -820,12 +820,12 @@ int xcfun_set(xcfun_t * fun, const char * name, double value) {
  *
  * param[in] fun the functional object
  * param[in] name functional name to test, aliases not supported
- * param[out] value weight of functional
+ * param[in,out] value weight of functional
  *
  * Returns 0 if name is a valid functional, -1 if not.
  * See list_of_functionals.hpp for valid functional names.
  */
-int xcfun_get(const xcfun_t * fun, const char * name, double value[]) {
+int xcfun_get(const xcfun_t * fun, const char * name, double * value) {
   return xcfun::xcfun_get(AS_CTYPE(XCFunctional, fun), name, value);
 }
 

--- a/src/XCFunctional.hpp
+++ b/src/XCFunctional.hpp
@@ -37,7 +37,7 @@ namespace xcfun {
 XCFunctional * xcfun_new();
 void xcfun_delete(XCFunctional *);
 int xcfun_set(XCFunctional * fun, const char * name, double value);
-int xcfun_get(const XCFunctional * fun, const char * name, double value[]);
+int xcfun_get(const XCFunctional * fun, const char * name, double * value);
 bool xcfun_is_gga(const XCFunctional * fun);
 bool xcfun_is_metagga(const XCFunctional * fun);
 int xcfun_eval_setup(XCFunctional * fun,


### PR DESCRIPTION
It was declared to accept an array of doubles, but the pointer type was really only meant as an in-out parameter.

The problem was caught when using it from Fortran (for the C/C++ type system a pointer as an in-out parameter or as an array is the same thing). I have thus edited the example to exercise the `xcfun_get` function as a test.

The proper solution would be to return the `weight`, rather than accept it as in-out parameter (with confusing semantics...) This requires rolling back the `return` for error codes in favor of just quitting on errors. I am working on it in another branch.

I'll mint a `v2.0.0a4` as soon as this gets merged.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Status
<!--- Check this box when ready to be merged -->
- [X]  Ready to go
