### PR TITLE
Handle 64-bit integers in Fortran properly

### DIFF
--- a/examples/Fortran_host/CMakeLists.txt
+++ b/examples/Fortran_host/CMakeLists.txt
@@ -35,6 +35,10 @@ enable_testing()
 
 foreach(_src example)
   add_executable(${_src} ${_src}.f90)
+  target_compile_options(${_src}
+    PUBLIC
+      "-fdefault-integer-8"
+    )
   target_sources(${_src}
     PRIVATE
       ${XCFun_Fortran_SOURCES}

--- a/examples/Fortran_host/example.f90
+++ b/examples/Fortran_host/example.f90
@@ -24,7 +24,11 @@ program xc_example
 
   use xcfun, only: XC_CONTRACTED, &
                    XC_N_NX_NY_NZ, &
+                   xcfun_test, &
                    xcfun_splash, &
+                   xcfun_is_compatible_library, &
+                   xcfun_which_vars, &
+                   xcfun_which_mode, &
                    xcfun_new, &
                    xcfun_set, &
                    xcfun_get, &
@@ -47,11 +51,18 @@ program xc_example
   integer, parameter :: num_density_variables = 4
 
   integer :: order, ierr, ipoint
-  integer :: vector_length
+  integer :: vector_length, foo
   real(8) :: res, weight
 
   real(8), allocatable :: density(:, :, :)
 
+  ierr = xcfun_test()
+  call assert(ierr == 0, "xcfun_test failed")
+
+  print *, 'Is library version compatible? ', xcfun_is_compatible_library()
+
+  foo = xcfun_which_vars(1, 0, 0, 0, 0, 0)
+  foo = xcfun_which_mode(3)
 
   ! print some info and copyright about the library
   ! please always include this info in your code


### PR DESCRIPTION
This fixes compiler errors when setting default integer size to 64-bit in Fortran hosts.

Just a comment. I don't understand why the use of 64-bit integers in Fortran is a thing. But it poses an  undue burden on library developers. And it is not fun. To any developer of a Fortran host to XCFun: this one commit is one hour of my life I will never get back. 
