### PR TITLE
fixed grad reg for SCAN functionals, calculate p directly

### DIFF
--- a/src/functionals/SCAN_like_eps.hpp
+++ b/src/functionals/SCAN_like_eps.hpp
@@ -115,19 +115,22 @@ static num get_SCAN_Fx(const num d_n,
     printf("ERROR: Unknown IALPHA %d\n", IALPHA);
   }
 
-  num s = 0.0;
+  num p = 0.0;
   if (abs(d_g) > 1.0e-16) {
-    s = sqrt(d_g) /
-        (2.0 * pow(3.0 * PI2, 1.0 / 3.0) * pow(d_n, 4.0 / 3.0)); // Eq. (4)
-  };
+    p = d_g /
+        (4.0 * pow(3.0 * PI2, 2.0 / 3.0) * pow(d_n, 8.0 / 3.0));
+  } else {
+    p = 1e-16/
+        (4.0 * pow(3.0 * PI2, 2.0 / 3.0) * pow(d_n, 8.0 / 3.0));
+  }
 
-  num Fx = SCAN_X_Fx(s, alpha, ETA, IINTERP, IDELFX);
+  num Fx = SCAN_X_Fx(p, alpha, ETA, IINTERP, IDELFX);
 
   return Fx;
 }
 
 template <class num>
-static num SCAN_X_Fx(const num s,
+static num SCAN_X_Fx(const num p,
                      const num alpha,
                      const parameter ETA,
                      const int IINTERP,
@@ -188,7 +191,6 @@ static num SCAN_X_Fx(const num s,
   num h0x = 1.0 + K0;
 
   // Slowly varying enhancement
-  num p = s * s;
   num del_f2 = 0.0;
   num C2 = 0.0;
   num h1x = 0.0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Use labels to help the developers -->
<!--- Remove the unnecessary sections when filing -->

## Description
<!--- Describe your changes in detail -->

Fixed regularisation of SCAN-like functionals for small gradients.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This solves the issue of SCAN-like functionals returning NaN when the gradient is small. See issue #144.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated code passes previously set tests.

## Screenshots (if appropriate):

## Todos
<!--- Notable points that this PR has either accomplished or will accomplish. -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Questions
<!--- Questions to the developers -->

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go
