### PR TITLE
Fix pitch values in xcfun_eval_vec/xcfun.f90

### DIFF
--- a/api/xcfun.f90
+++ b/api/xcfun.f90
@@ -478,8 +478,8 @@ contains
     integer(c_int) :: r_pitch
 
     n = int(nr_points)
-    d_pitch = int(size(density) - 1, kind=c_int)
-    r_pitch = int(size(res) - 1, kind=c_int)
+    d_pitch = int(size(density(:,1)), kind=c_int)
+    r_pitch = int(size(res(:,1)), kind=c_int)
     call xcfun_eval_vec_C(fun, n, density, d_pitch, res, r_pitch)
   end subroutine
 end module


### PR DESCRIPTION
The pitch sizes computed in xcfun_eval_vec must correspond to the number of density/potential
values per grid point.