### PR TITLE
Add error message in static_assert

### DIFF
--- a/src/functionals/brx.cpp
+++ b/src/functionals/brx.cpp
@@ -51,7 +51,7 @@ static double BR(double z) {
 // inverse of BR_y. Use linear method for simplicity.
 template <typename T, int Ndeg>
 taylor <T, 1, Ndeg> BR_taylor(const T & z0) {
-  static_assert(Ndeg >= 3);
+  static_assert(Ndeg >= 3, "Polynomial degree must be at least 3!");
 
   taylor<T, 1, Ndeg> t;
   t = 0;


### PR DESCRIPTION
It is optional only when compiling with C++17 or later. Fixes #157 