### PR TITLE
Decrease P86C fudge factor from 1e-12 to DBL_EPSILON.

### DIFF
--- a/src/functionals/p86c.cpp
+++ b/src/functionals/p86c.cpp
@@ -15,6 +15,7 @@
 #include "constants.hpp"
 #include "functional.hpp"
 #include "pz81c.hpp"
+#include <cfloat>
 
 template <typename num> static num Cg(const num & r) {
   parameter Cx = 0.001667;
@@ -26,7 +27,7 @@ template <typename num> static num Cg(const num & r) {
 template <typename num> static num Pg(const densvars<num> & d) {
   parameter Fg = 0.11;
   parameter Cinf = 0.004235;
-  parameter fudge = 1e-12; // Avoid instability at d.gnn = 0
+  parameter fudge = DBL_EPSILON; // Avoid instability at d.gnn = 0
 #ifndef INEXACT_PI
   parameter pi_expr = pow(9 * M_PI, 1.0 / 6.0);
 #else

--- a/src/functionals/p86c.cpp
+++ b/src/functionals/p86c.cpp
@@ -53,8 +53,8 @@ template <typename num> static num p86c_corr(const densvars<num> & d) {
 
 FUNCTIONAL(XC_P86C) = {
     "P86C GGA correlation",
-    "J.P. Density-functional approximation for the correlation energy\n"
-    "of the inhomogeneous electron , Phys. Rev. B, 33(12):8822gasPerdew,\n"
+    "J. P. Perdew, Density-functional approximation for the correlation energy\n"
+    "of the inhomogeneous electron, Phys. Rev. B 33, 8822 (1986).\n"
     "Implemented by Ulf Ekstrom.\n"
     "Reference data from ftp://ftp.dl.ac.uk/qcg/dft_library/data_pt_c_p86.html",
     XC_DENSITY | XC_GRADIENT,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Use labels to help the developers -->
<!--- Remove the unnecessary sections when filing -->

## Description
<!--- Describe your changes in detail -->
Decreases the fudge factor in P86C from `1e-12` to `DBL_EPSILON`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows exact agreement with Libxc. Closes #161 .

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in atomic calculations with AtomicOrbitals. Agreement to 9 decimals with the change.

## Screenshots (if appropriate):

## Todos
<!--- Notable points that this PR has either accomplished or will accomplish. -->
* **Developer Interest**
<!--- Changes affecting developers -->
  - [ ] Feature1
* **User-Facing for Release Notes**
<!--- Changes affecting users -->
  - [ ] Feature2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This changes the result, but only by tens of nanohartrees.

## Questions
<!--- Questions to the developers -->
- [ ]  Question1

## Status
<!--- Check this box when ready to be merged -->
- [x]  Ready to go
