### PR TITLE
Fix description of comment of XCFUN_REF_PBEX_MU

### DIFF
--- a/src/config.hpp
+++ b/src/config.hpp
@@ -35,7 +35,7 @@ inline void die(const char * message, int code) {
 // Use #define XCFUN_REF_PW92C to use inaccurate constants in
 // PW92C. This matches the reference implementation.
 
-// Use inaccurate mu value in pbe exchange.
+// Use accurate mu value in pbe exchange.
 // #define XCFUN_REF_PBEX_MU
 
 // This is the internal scalar type of the library, can be


### PR DESCRIPTION
By default, XCFun employs a non-standard value for mu in PBE exchange. The comment in `config.hpp` for `XCFUN_REF_PBEX_MU` is incorrect; this PR fixes that issue.