### PR TITLE
Add pytest dependency

### DIFF
--- a/docs/building.rst
+++ b/docs/building.rst
@@ -34,6 +34,9 @@ To compile the Python bindings:
 - Python 3.6+ and its development libraries and headers.
 - `pybind11 <https://pybind11.readthedocs.io>`_. This will be automatically
   downloaded if not available.
+  
+To test the Python bindings:
+- `pytest`
 
 To compile the documentation:
 

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -34,9 +34,7 @@ To compile the Python bindings:
 - Python 3.6+ and its development libraries and headers.
 - `pybind11 <https://pybind11.readthedocs.io>`_. This will be automatically
   downloaded if not available.
-  
-To test the Python bindings:
-- `pytest`
+- Other dependencies listed in the `requirements.txt` or `environment.yml` files.
 
 To compile the documentation:
 


### PR DESCRIPTION
`ctest` proceeds to test the Python bindings via the `pytest`, which is not a built-in Python package.
Thus, `ctest` fails if `pytest` is not installed. The source of failure is only visible when `ctest -V` is invoked.

It might be a good idea to document an optional `pytest` dependency and/or install it automatically (as `pybind11`).

## Description
Add `pytest` to the list of dependencies.

## Motivation and Context
`ctest` proceeds to test the Python bindings via the `pytest`, which is not a built-in Python package.
Thus, `ctest` fails if `pytest` is not installed.

## How Has This Been Tested?
No testing required. No side effects on the source code.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Questions
- [ ]  Should `pytest` be installed automatically (if not yet present) when `XCFUN_PYTHON_INTERFACE` is `ON` ?

## Status
- [X]  Ready to go
